### PR TITLE
Low-Hanging Fruits: safe one-click cleanup mode

### DIFF
--- a/Sources/SpaceMatters/Scanner/CleanupEngine.swift
+++ b/Sources/SpaceMatters/Scanner/CleanupEngine.swift
@@ -1,0 +1,204 @@
+import Foundation
+
+/// A known-safe cleanup target for the Low-Hanging Fruits mode: a location whose
+/// contents are regenerable by design (package/build caches) or explicitly
+/// disposable (the Trash). Paths are absolute; only existing ones are shown.
+struct Cleanable: Identifiable, Equatable, Sendable {
+    let id: String
+    let name: String
+    let category: String
+    let icon: String
+    /// What deleting costs the user ("re-downloaded on next install", …).
+    let note: String
+    let paths: [String]
+}
+
+/// Catalog, sizing and cleaning for the Low-Hanging Fruits mode.
+///
+/// Safety model (same spirit as `ScanController.remove`, J4.4):
+/// - the catalog is hand-picked — nothing is discovered dynamically;
+/// - every operation is fenced inside `allowedRoot` (the user's home), so a
+///   mis-built `Cleanable` can never reach outside it;
+/// - cleaning deletes the *children* of a cache directory, never the directory
+///   itself, and never follows symlinks: a link inside a cache is removed as a
+///   link, its target is left untouched; a cache root that *is* a symlink is
+///   refused outright rather than resolved.
+enum CleanupEngine {
+
+    // MARK: Catalog
+
+    /// Everything here is regenerable: emptying only costs a re-download or a
+    /// rebuild. Entries whose paths don't exist are filtered out by `detect`.
+    static func catalog(home: String = NSHomeDirectory()) -> [Cleanable] {
+        [
+            Cleanable(
+                id: "trash", name: "Trash", category: "System", icon: "trash.fill",
+                note: "Files you already deleted. Emptying is permanent.",
+                paths: [home + "/.Trash"]),
+            Cleanable(
+                id: "derived-data", name: "Xcode DerivedData", category: "Apple development", icon: "hammer.fill",
+                note: "Per-project build artifacts. Xcode rebuilds them on demand.",
+                paths: [home + "/Library/Developer/Xcode/DerivedData"]),
+            Cleanable(
+                id: "swiftpm", name: "SwiftPM cache", category: "Apple development", icon: "shippingbox.fill",
+                note: "Package checkouts and manifests, re-fetched on next resolve.",
+                paths: [home + "/Library/Caches/org.swift.swiftpm"]),
+            Cleanable(
+                id: "cocoapods", name: "CocoaPods cache", category: "Apple development", icon: "cube.fill",
+                note: "Downloaded pod specs and archives, re-fetched on next install.",
+                paths: [home + "/Library/Caches/CocoaPods"]),
+            Cleanable(
+                id: "npm", name: "npm cache", category: "JavaScript", icon: "shippingbox",
+                note: "Package tarballs, re-downloaded on next install.",
+                paths: [home + "/.npm/_cacache"]),
+            Cleanable(
+                id: "yarn", name: "Yarn cache", category: "JavaScript", icon: "shippingbox",
+                note: "Package tarballs, re-downloaded on next install.",
+                paths: [home + "/Library/Caches/Yarn"]),
+            Cleanable(
+                id: "pnpm", name: "pnpm store", category: "JavaScript", icon: "shippingbox",
+                note: "Content-addressable package store, re-downloaded on demand.",
+                paths: [home + "/Library/pnpm/store", home + "/.pnpm-store"]),
+            Cleanable(
+                id: "nuget", name: "NuGet packages", category: ".NET", icon: "archivebox.fill",
+                note: "Global packages + HTTP cache, restored on next build.",
+                paths: [
+                    home + "/.nuget/packages",
+                    home + "/.local/share/NuGet/http-cache",
+                    home + "/.local/share/NuGet/v3-cache",
+                ]),
+            Cleanable(
+                id: "pip", name: "pip cache", category: "Python", icon: "archivebox",
+                note: "Wheel downloads, re-fetched on next install.",
+                paths: [home + "/Library/Caches/pip"]),
+            Cleanable(
+                id: "uv", name: "uv cache", category: "Python", icon: "archivebox",
+                note: "Package cache, re-fetched on next sync.",
+                paths: [home + "/Library/Caches/uv"]),
+            Cleanable(
+                id: "gradle", name: "Gradle caches", category: "JVM", icon: "gearshape.2.fill",
+                note: "Dependency and build caches, re-downloaded on next build.",
+                paths: [home + "/.gradle/caches"]),
+            Cleanable(
+                id: "maven", name: "Maven repository", category: "JVM", icon: "gearshape.2",
+                note: "Local artifact repository, re-downloaded on next build.",
+                paths: [home + "/.m2/repository"]),
+            Cleanable(
+                id: "cargo", name: "Cargo registry", category: "Rust & Go", icon: "wrench.and.screwdriver.fill",
+                note: "Crate downloads and sources, re-fetched on next build.",
+                paths: [home + "/.cargo/registry"]),
+            Cleanable(
+                id: "go-build", name: "Go build cache", category: "Rust & Go", icon: "wrench.and.screwdriver",
+                note: "Compiled build cache, rebuilt on demand.",
+                paths: [home + "/Library/Caches/go-build"]),
+            Cleanable(
+                id: "homebrew", name: "Homebrew downloads", category: "Homebrew", icon: "mug.fill",
+                note: "Bottle and formula downloads (what `brew cleanup` removes).",
+                paths: [home + "/Library/Caches/Homebrew"]),
+        ]
+    }
+
+    /// The catalog restricted to entries with at least one existing path.
+    static func detect(_ catalog: [Cleanable]) -> [Cleanable] {
+        catalog.compactMap { item in
+            let existing = item.paths.filter { FileManager.default.fileExists(atPath: $0) }
+            guard !existing.isEmpty else { return nil }
+            return Cleanable(id: item.id, name: item.name, category: item.category,
+                             icon: item.icon, note: item.note, paths: existing)
+        }
+    }
+
+    // MARK: Sizing
+
+    enum Measure: Equatable, Sendable {
+        case sized(Int64)
+        /// The location exists but can't be opened — typically the Trash without
+        /// Full Disk Access.
+        case denied
+    }
+
+    /// Physical bytes under the item's paths, via the same `getattrlistbulk`
+    /// walk as the scanner (symlinks counted as their own size, never followed;
+    /// mount points not crossed). Runs off the main thread.
+    static func size(of item: Cleanable) -> Measure {
+        var total: Int64 = 0
+        var openedAny = false
+        let buffer = UnsafeMutableRawPointer.allocate(byteCount: bufferSize, alignment: 16)
+        defer { buffer.deallocate() }
+
+        for root in item.paths {
+            var stack = [root]
+            while let dir = stack.popLast() {
+                let fd = open(dir, O_RDONLY | O_DIRECTORY)
+                guard fd >= 0 else { continue }
+                if dir == root { openedAny = true }
+                let prefix = dir + "/"
+                _ = enumerateDirectory(fd: fd, buffer: buffer, bufferSize: bufferSize) { entry in
+                    if entry.isDirectory {
+                        if entry.isMountPoint { return }
+                        let name = String(
+                            decoding: UnsafeRawBufferPointer(start: entry.name, count: entry.nameLength),
+                            as: UTF8.self
+                        )
+                        stack.append(prefix + name)
+                    } else {
+                        total += entry.physicalSize
+                    }
+                }
+                close(fd)
+            }
+        }
+        return openedAny ? .sized(total) : .denied
+    }
+
+    // MARK: Cleaning
+
+    struct CleanResult: Equatable, Sendable {
+        var removed = 0
+        var failed = 0
+        /// Paths refused by the safety fence (outside `allowedRoot`, or a
+        /// symlinked root) — a bug indicator, surfaced rather than swallowed.
+        var refused = 0
+    }
+
+    /// Delete the *children* of each of the item's paths. The paths themselves
+    /// survive (tools expect their cache directory to exist). Every path must
+    /// live strictly inside `allowedRoot` and be a real directory — a symlinked
+    /// root is refused, so a cache relocated elsewhere is never chased.
+    static func clean(_ item: Cleanable, allowedRoot: String = NSHomeDirectory()) -> CleanResult {
+        var result = CleanResult()
+        let fm = FileManager.default
+        let fence = allowedRoot.hasSuffix("/") ? allowedRoot : allowedRoot + "/"
+
+        for root in item.paths {
+            guard root.hasPrefix(fence), root != fence, isRealDirectory(root) else {
+                result.refused += 1
+                continue
+            }
+            guard let children = try? fm.contentsOfDirectory(atPath: root) else {
+                result.failed += 1
+                continue
+            }
+            for child in children {
+                // removeItem on a symlink deletes the link, not its target.
+                do {
+                    try fm.removeItem(atPath: root + "/" + child)
+                    result.removed += 1
+                } catch {
+                    result.failed += 1
+                }
+            }
+        }
+        return result
+    }
+
+    /// True only for a directory that is not itself a symlink (`lstat`, so the
+    /// check applies to the entry, not to what it may point at).
+    private static func isRealDirectory(_ path: String) -> Bool {
+        var st = stat()
+        guard lstat(path, &st) == 0 else { return false }
+        return (st.st_mode & S_IFMT) == S_IFDIR
+    }
+
+    private static let bufferSize = 256 * 1024
+}

--- a/Sources/SpaceMatters/ViewModel/AppModel.swift
+++ b/Sources/SpaceMatters/ViewModel/AppModel.swift
@@ -8,17 +8,19 @@ import Observation
 @MainActor
 @Observable
 final class AppModel {
-    enum Route: Equatable { case splash, filesystem, containers, kubernetes }
+    enum Route: Equatable { case splash, filesystem, containers, kubernetes, cleanup }
     private(set) var route: Route = .splash
 
     let filesystem = ScanController()
     let containers = ContainerController()
     let kubernetes = KubernetesController()
+    let cleanup = CleanupController()
 
     func showSplash() {
         filesystem.goHome()
         containers.stop()
         kubernetes.stop()
+        cleanup.stop()
         route = .splash
     }
 
@@ -76,5 +78,12 @@ final class AppModel {
     func analyzeKubernetes(context: String) {
         route = .kubernetes
         kubernetes.load(context: context)
+    }
+
+    // MARK: Cleanup mode (Low-Hanging Fruits)
+
+    func analyzeCleanup() {
+        route = .cleanup
+        cleanup.load()
     }
 }

--- a/Sources/SpaceMatters/ViewModel/CleanupController.swift
+++ b/Sources/SpaceMatters/ViewModel/CleanupController.swift
@@ -72,6 +72,27 @@ final class CleanupController {
         rows[idx].selected.toggle()
     }
 
+    // MARK: Select all (tri-state)
+
+    enum SelectAllState { case none, some, all }
+
+    /// Select-all checkbox state over the *selectable* rows (denied/pending
+    /// rows have no trustworthy size and never count).
+    var selectAllState: SelectAllState {
+        let selectable = rows.filter(\.size.isSelectable)
+        let selected = selectable.filter(\.selected).count
+        if selected == 0 { return .none }
+        return selected == selectable.count ? .all : .some
+    }
+
+    /// Standard macOS cycle: all → none; none or mixed → all.
+    func toggleAll() {
+        let target = selectAllState != .all
+        for idx in rows.indices {
+            rows[idx].selected = target && rows[idx].size.isSelectable
+        }
+    }
+
     // MARK: Derived totals
 
     var selectedRows: [Row] { rows.filter(\.selected) }
@@ -136,5 +157,12 @@ extension CleanupController.SizeState {
     var bytes: Int64 {
         if case .sized(let value) = self { return value }
         return 0
+    }
+
+    /// Only measured rows can be selected — a denied or still-sizing row has no
+    /// trustworthy size to confirm against.
+    var isSelectable: Bool {
+        if case .sized = self { return true }
+        return false
     }
 }

--- a/Sources/SpaceMatters/ViewModel/CleanupController.swift
+++ b/Sources/SpaceMatters/ViewModel/CleanupController.swift
@@ -1,0 +1,140 @@
+import Foundation
+import Observation
+
+/// Drives the Low-Hanging Fruits mode: detects the known-safe cleanup targets,
+/// sizes them concurrently (rows fill in live, like a scan), and empties the
+/// selected ones. Nothing is pre-selected — cleaning is always an explicit
+/// choice, and it is refused while sizing or another clean is in flight.
+@MainActor
+@Observable
+final class CleanupController {
+    enum State: Equatable { case idle, sizing, ready, cleaning }
+
+    enum SizeState: Equatable {
+        case pending
+        case sized(Int64)
+        /// Exists but unreadable — typically the Trash without Full Disk Access.
+        case denied
+    }
+
+    struct Row: Identifiable {
+        let item: Cleanable
+        var size: SizeState = .pending
+        var selected = false
+        var id: String { item.id }
+    }
+
+    private(set) var state: State = .idle
+    private(set) var rows: [Row] = []
+    /// Bytes freed by the last clean (before/after sizing difference).
+    private(set) var lastFreed: Int64 = 0
+    /// Children that could not be removed during the last clean (locked files…).
+    private(set) var lastFailures = 0
+
+    private let catalog: [Cleanable]
+    private let allowedRoot: String
+    private var loadID = 0 // invalidates in-flight sizing (same pattern as Kubernetes mode)
+
+    /// `catalog`/`allowedRoot` are injectable so tests can run against fixtures;
+    /// the app uses the built-in catalog fenced to the user's home.
+    init(catalog: [Cleanable] = CleanupEngine.catalog(),
+         allowedRoot: String = NSHomeDirectory()) {
+        self.catalog = catalog
+        self.allowedRoot = allowedRoot
+    }
+
+    func load() {
+        loadID += 1
+        let id = loadID
+        lastFreed = 0
+        lastFailures = 0
+        let detected = CleanupEngine.detect(catalog)
+        // Keep existing selections across a refresh; drop ones that vanished.
+        let previouslySelected = Set(rows.filter(\.selected).map(\.id))
+        rows = detected.map { Row(item: $0, selected: previouslySelected.contains($0.id)) }
+        state = rows.isEmpty ? .ready : .sizing
+        for item in detected {
+            Task {
+                let measure = await Task.detached(priority: .userInitiated) {
+                    CleanupEngine.size(of: item)
+                }.value
+                guard id == self.loadID else { return }
+                self.apply(measure, to: item.id)
+            }
+        }
+    }
+
+    func refresh() { load() }
+    func stop() { loadID += 1 }
+
+    func toggle(_ id: String) {
+        guard let idx = rows.firstIndex(where: { $0.id == id }) else { return }
+        rows[idx].selected.toggle()
+    }
+
+    // MARK: Derived totals
+
+    var selectedRows: [Row] { rows.filter(\.selected) }
+
+    /// Sum of the sized rows (the "found" total in the summary strip).
+    var totalFound: Int64 { rows.reduce(0) { $0 + $1.size.bytes } }
+    var totalSelected: Int64 { selectedRows.reduce(0) { $0 + $1.size.bytes } }
+
+    var categories: [String] {
+        var seen: Set<String> = []
+        return rows.map(\.item.category).filter { seen.insert($0).inserted }
+    }
+
+    func rows(in category: String) -> [Row] {
+        rows.filter { $0.item.category == category }
+    }
+
+    // MARK: Cleaning
+
+    /// Empty the selected targets, then re-size them so the freed bytes shown
+    /// are measured, not assumed. Only runs from `.ready` — never mid-sizing.
+    func cleanSelected() async {
+        guard state == .ready, !selectedRows.isEmpty else { return }
+        state = .cleaning
+        let before = totalSelected
+        let targets = selectedRows.map(\.item)
+        let root = allowedRoot
+
+        var failures = 0
+        for item in targets {
+            let result = await Task.detached(priority: .userInitiated) {
+                CleanupEngine.clean(item, allowedRoot: root)
+            }.value
+            failures += result.failed + result.refused
+            let measure = await Task.detached(priority: .userInitiated) {
+                CleanupEngine.size(of: item)
+            }.value
+            apply(measure, to: item.id)
+        }
+
+        lastFailures = failures
+        lastFreed = max(0, before - totalSelected)
+        for idx in rows.indices { rows[idx].selected = false }
+        state = .ready
+    }
+
+    // MARK: Private
+
+    private func apply(_ measure: CleanupEngine.Measure, to id: String) {
+        guard let idx = rows.firstIndex(where: { $0.id == id }) else { return }
+        switch measure {
+        case .sized(let bytes): rows[idx].size = .sized(bytes)
+        case .denied: rows[idx].size = .denied
+        }
+        if state == .sizing, !rows.contains(where: { $0.size == .pending }) {
+            state = .ready
+        }
+    }
+}
+
+extension CleanupController.SizeState {
+    var bytes: Int64 {
+        if case .sized(let value) = self { return value }
+        return 0
+    }
+}

--- a/Sources/SpaceMatters/Views/CleanupResultView.swift
+++ b/Sources/SpaceMatters/Views/CleanupResultView.swift
@@ -1,0 +1,267 @@
+import SwiftUI
+
+/// Low-Hanging Fruits mode: the known-safe cleanup targets found on this Mac,
+/// sized live, grouped by category. Nothing is pre-selected; cleaning asks for
+/// confirmation and reports measured (not assumed) freed bytes.
+struct CleanupResultView: View {
+    @Bindable var controller: CleanupController
+    let app: AppModel
+    @Binding var isDark: Bool
+    @Environment(\.theme) private var theme
+
+    @State private var confirmClean = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            toolbar
+            Divider().overlay(theme.separator)
+            summaryStrip
+            Divider().overlay(theme.separator)
+
+            if controller.rows.isEmpty {
+                VStack(spacing: 10) {
+                    Image(systemName: "sparkles")
+                        .font(.system(size: 32)).foregroundStyle(theme.textSecondary)
+                    Text("Nothing to clean — no known caches found.")
+                        .font(.system(size: 12)).foregroundStyle(theme.textSecondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                list
+            }
+
+            Divider().overlay(theme.separator)
+            footer
+        }
+        .background(theme.windowBackground)
+        .alert("Clean selected items?", isPresented: $confirmClean) {
+            Button("Clean", role: .destructive) {
+                Task { await controller.cleanSelected() }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(confirmMessage)
+        }
+    }
+
+    private var confirmMessage: String {
+        let names = controller.selectedRows.map(\.item.name).joined(separator: ", ")
+        return "\(names) — about \(Format.bytes(controller.totalSelected)) will be reclaimed. "
+            + "Caches are re-downloaded or rebuilt on demand; emptying the Trash is permanent."
+    }
+
+    // MARK: Toolbar
+
+    private var toolbar: some View {
+        HStack(spacing: 12) {
+            Button(action: app.showSplash) {
+                Label("Home", systemImage: "chevron.backward")
+            }
+            .buttonStyle(.plain).foregroundStyle(theme.textPrimary)
+
+            Button(action: controller.refresh) {
+                Label("Refresh", systemImage: "arrow.clockwise")
+            }
+            .buttonStyle(.plain).foregroundStyle(theme.textPrimary)
+            .disabled(controller.state == .cleaning)
+
+            Divider().frame(height: 22).overlay(theme.separator)
+            Text("Low-Hanging Fruits")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(theme.textPrimary)
+
+            Spacer()
+
+            Button { isDark.toggle() } label: {
+                Image(systemName: isDark ? "sun.max.fill" : "moon.fill")
+            }
+            .buttonStyle(.plain).foregroundStyle(theme.textSecondary)
+        }
+        .padding(.horizontal, 14).padding(.vertical, 9)
+        .background(theme.panelBackground)
+    }
+
+    // MARK: Summary
+
+    private var summaryStrip: some View {
+        HStack(spacing: 12) {
+            summaryCard("Reclaimable found", value: Format.bytes(controller.totalFound),
+                        subtitle: controller.state == .sizing ? "still measuring…" : "\(controller.rows.count) locations")
+            summaryCard("Selected", value: Format.bytes(controller.totalSelected),
+                        subtitle: "\(controller.selectedRows.count) of \(controller.rows.count)")
+            if controller.lastFreed > 0 {
+                summaryCard("Freed", value: Format.bytes(controller.lastFreed),
+                            subtitle: controller.lastFailures > 0
+                                ? "\(controller.lastFailures) items couldn't be removed"
+                                : "measured after cleaning",
+                            accent: true)
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 14).padding(.vertical, 10)
+        .background(theme.panelBackground)
+    }
+
+    private func summaryCard(_ title: String, value: String, subtitle: String, accent: Bool = false) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title.uppercased())
+                .font(.system(size: 9, weight: .bold)).foregroundStyle(theme.textSecondary)
+            Text(value)
+                .font(.system(size: 17, weight: .semibold).monospacedDigit())
+                .foregroundStyle(accent ? theme.accent : theme.textPrimary)
+            Text(subtitle)
+                .font(.system(size: 10)).foregroundStyle(theme.textSecondary.opacity(0.8))
+        }
+        .frame(width: 190, alignment: .leading)
+        .padding(12)
+        .background(RoundedRectangle(cornerRadius: 10).fill(theme.windowBackground))
+        .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(theme.separator))
+    }
+
+    // MARK: List
+
+    private var list: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                ForEach(controller.categories, id: \.self) { category in
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(category)
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundStyle(theme.textSecondary)
+                            .textCase(.uppercase)
+                        VStack(spacing: 1) {
+                            ForEach(controller.rows(in: category)) { row in
+                                CleanupRowView(row: row, theme: theme,
+                                               disabled: controller.state == .cleaning) {
+                                    controller.toggle(row.id)
+                                }
+                            }
+                        }
+                        .background(RoundedRectangle(cornerRadius: 10).fill(theme.panelBackground))
+                        .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(theme.separator))
+                    }
+                }
+            }
+            .padding(14)
+            .frame(maxWidth: 900, alignment: .leading)
+            .frame(maxWidth: .infinity)
+        }
+    }
+
+    // MARK: Footer
+
+    private var footer: some View {
+        HStack(spacing: 12) {
+            if controller.state == .cleaning {
+                ProgressView().controlSize(.small)
+                Text("Cleaning…")
+                    .font(.system(size: 12)).foregroundStyle(theme.textSecondary)
+            } else {
+                Text("Everything here is safe to remove: caches are re-downloaded or rebuilt when needed.")
+                    .font(.system(size: 11)).foregroundStyle(theme.textSecondary)
+            }
+            Spacer()
+            Button { confirmClean = true } label: {
+                Text(controller.totalSelected > 0
+                     ? "Clean \(Format.bytes(controller.totalSelected))"
+                     : "Clean")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 14).padding(.vertical, 6)
+                    .background(Capsule().fill(controller.selectedRows.isEmpty
+                                               ? Color.gray.opacity(0.4) : Color(hex: 0xE0915A)))
+            }
+            .buttonStyle(.plain)
+            .disabled(controller.selectedRows.isEmpty || controller.state != .ready)
+        }
+        .padding(.horizontal, 14).padding(.vertical, 10)
+        .background(theme.panelBackground)
+    }
+}
+
+private struct CleanupRowView: View {
+    let row: CleanupController.Row
+    let theme: Theme
+    let disabled: Bool
+    let toggle: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Toggle("", isOn: Binding(get: { row.selected }, set: { _ in toggle() }))
+                .toggleStyle(.checkbox)
+                .labelsHidden()
+                .disabled(disabled || !row.size.isSelectable)
+
+            Image(systemName: row.item.icon)
+                .font(.system(size: 14))
+                .foregroundStyle(theme.accent)
+                .frame(width: 22)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(row.item.name)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(theme.textPrimary)
+                Text(row.item.note)
+                    .font(.system(size: 10))
+                    .foregroundStyle(theme.textSecondary)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            Text(row.item.paths.map(abbreviate).joined(separator: " · "))
+                .font(.system(size: 10))
+                .foregroundStyle(theme.textSecondary.opacity(0.7))
+                .lineLimit(1).truncationMode(.middle)
+                .frame(maxWidth: 260, alignment: .trailing)
+
+            sizeLabel
+                .frame(width: 90, alignment: .trailing)
+        }
+        .padding(.horizontal, 12).padding(.vertical, 8)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(row.item.name), \(sizeAccessibility)")
+    }
+
+    @ViewBuilder
+    private var sizeLabel: some View {
+        switch row.size {
+        case .pending:
+            ProgressView().controlSize(.mini)
+        case .sized(let bytes):
+            Text(Format.bytes(bytes))
+                .font(.system(size: 12, weight: .medium).monospacedDigit())
+                .foregroundStyle(theme.textPrimary)
+        case .denied:
+            Button(action: FullDiskAccess.openSettings) {
+                Label("Needs access", systemImage: "lock.fill")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(Color(hex: 0xE0915A))
+            }
+            .buttonStyle(.plain)
+            .help("Grant Full Disk Access to measure and clean this location")
+        }
+    }
+
+    private var sizeAccessibility: String {
+        switch row.size {
+        case .pending: return "measuring"
+        case .sized(let bytes): return Format.bytes(bytes)
+        case .denied: return "needs Full Disk Access"
+        }
+    }
+
+    private func abbreviate(_ path: String) -> String {
+        let home = NSHomeDirectory()
+        return path.hasPrefix(home) ? "~" + path.dropFirst(home.count) : path
+    }
+}
+
+extension CleanupController.SizeState {
+    /// Only measured rows can be selected — a denied or still-sizing row has no
+    /// trustworthy size to confirm against.
+    var isSelectable: Bool {
+        if case .sized = self { return true }
+        return false
+    }
+}

--- a/Sources/SpaceMatters/Views/CleanupResultView.swift
+++ b/Sources/SpaceMatters/Views/CleanupResultView.swift
@@ -98,53 +98,92 @@ struct CleanupResultView: View {
             }
             Spacer()
         }
-        .padding(.horizontal, 14).padding(.vertical, 10)
+        .padding(.horizontal, 14).padding(.vertical, 8)
         .background(theme.panelBackground)
     }
 
     private func summaryCard(_ title: String, value: String, subtitle: String, accent: Bool = false) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: 2) {
             Text(title.uppercased())
                 .font(.system(size: 9, weight: .bold)).foregroundStyle(theme.textSecondary)
             Text(value)
-                .font(.system(size: 17, weight: .semibold).monospacedDigit())
+                .font(.system(size: 15, weight: .semibold).monospacedDigit())
                 .foregroundStyle(accent ? theme.accent : theme.textPrimary)
             Text(subtitle)
-                .font(.system(size: 10)).foregroundStyle(theme.textSecondary.opacity(0.8))
+                .font(.system(size: 9)).foregroundStyle(theme.textSecondary.opacity(0.8))
         }
-        .frame(width: 190, alignment: .leading)
-        .padding(12)
-        .background(RoundedRectangle(cornerRadius: 10).fill(theme.windowBackground))
-        .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(theme.separator))
+        .frame(width: 170, alignment: .leading)
+        .padding(.horizontal, 10).padding(.vertical, 7)
+        .background(RoundedRectangle(cornerRadius: 8).fill(theme.windowBackground))
+        .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(theme.separator))
     }
 
     // MARK: List
 
+    /// One table-like panel: a header row carrying the select-all checkbox
+    /// (same container and paddings as the rows, so the checkbox column lines
+    /// up exactly), category bands inside it, hairlines between rows. Full
+    /// width, aligned with the summary strip.
     private var list: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
+            VStack(spacing: 0) {
+                selectAllHeader
                 ForEach(controller.categories, id: \.self) { category in
-                    VStack(alignment: .leading, spacing: 6) {
-                        Text(category)
-                            .font(.system(size: 11, weight: .semibold))
-                            .foregroundStyle(theme.textSecondary)
-                            .textCase(.uppercase)
-                        VStack(spacing: 1) {
-                            ForEach(controller.rows(in: category)) { row in
-                                CleanupRowView(row: row, theme: theme,
-                                               disabled: controller.state == .cleaning) {
-                                    controller.toggle(row.id)
-                                }
-                            }
+                    Divider().overlay(theme.separator)
+                    Text(category)
+                        .font(.system(size: 9, weight: .bold))
+                        .foregroundStyle(theme.textSecondary)
+                        .textCase(.uppercase)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 10).padding(.vertical, 4)
+                        .background(theme.windowBackground.opacity(0.6))
+                    let rows = controller.rows(in: category)
+                    ForEach(Array(rows.enumerated()), id: \.element.id) { idx, row in
+                        if idx > 0 {
+                            Divider().overlay(theme.separator.opacity(0.5)).padding(.leading, 36)
                         }
-                        .background(RoundedRectangle(cornerRadius: 10).fill(theme.panelBackground))
-                        .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(theme.separator))
+                        CleanupRowView(row: row, theme: theme,
+                                       disabled: controller.state == .cleaning) {
+                            controller.toggle(row.id)
+                        }
                     }
                 }
             }
+            .background(theme.panelBackground)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(theme.separator))
             .padding(14)
-            .frame(maxWidth: 900, alignment: .leading)
-            .frame(maxWidth: .infinity)
+        }
+    }
+
+    /// Header row of the table: the tri-state select-all checkbox, in the same
+    /// column as the row checkboxes below it.
+    private var selectAllHeader: some View {
+        HStack(spacing: 8) {
+            CheckSquare(state: selectAllCheckState, theme: theme,
+                        disabled: controller.state == .cleaning) {
+                controller.toggleAll()
+            }
+            .accessibilityLabel("Select all")
+            Text("Select all")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(theme.textPrimary)
+            Spacer()
+            Text(Format.bytes(controller.totalSelected))
+                .font(.system(size: 11, weight: .medium).monospacedDigit())
+                .foregroundStyle(controller.totalSelected > 0 ? theme.textPrimary : theme.textSecondary.opacity(0.6))
+                .frame(width: 80, alignment: .trailing)
+        }
+        .padding(.horizontal, 10).padding(.vertical, 6)
+        .contentShape(Rectangle())
+        .onTapGesture { if controller.state != .cleaning { controller.toggleAll() } }
+    }
+
+    private var selectAllCheckState: CheckSquare.CheckState {
+        switch controller.selectAllState {
+        case .none: return .off
+        case .some: return .mixed
+        case .all: return .on
         }
     }
 
@@ -179,6 +218,37 @@ struct CleanupResultView: View {
     }
 }
 
+/// Checkbox drawn from SF Symbols so the select-all checkbox can show a mixed
+/// state (SwiftUI's native `.checkbox` toggle is two-state only) and every
+/// checkbox in the list shares one look.
+private struct CheckSquare: View {
+    enum CheckState { case off, on, mixed }
+    let state: CheckState
+    let theme: Theme
+    let disabled: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: symbol)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(state == .off ? theme.textSecondary : theme.accent)
+                .opacity(disabled ? 0.4 : 1)
+        }
+        .buttonStyle(.plain)
+        .disabled(disabled)
+        .accessibilityValue(state == .on ? "checked" : state == .mixed ? "partially checked" : "unchecked")
+    }
+
+    private var symbol: String {
+        switch state {
+        case .off: return "square"
+        case .on: return "checkmark.square.fill"
+        case .mixed: return "minus.square.fill"
+        }
+    }
+}
+
 private struct CleanupRowView: View {
     let row: CleanupController.Row
     let theme: Theme
@@ -186,28 +256,28 @@ private struct CleanupRowView: View {
     let toggle: () -> Void
 
     var body: some View {
-        HStack(spacing: 10) {
-            Toggle("", isOn: Binding(get: { row.selected }, set: { _ in toggle() }))
-                .toggleStyle(.checkbox)
-                .labelsHidden()
-                .disabled(disabled || !row.size.isSelectable)
+        HStack(spacing: 8) {
+            CheckSquare(state: row.selected ? .on : .off, theme: theme,
+                        disabled: disabled || !row.size.isSelectable, action: toggle)
 
             Image(systemName: row.item.icon)
-                .font(.system(size: 14))
+                .font(.system(size: 12))
                 .foregroundStyle(theme.accent)
-                .frame(width: 22)
+                .frame(width: 18)
 
-            VStack(alignment: .leading, spacing: 1) {
-                Text(row.item.name)
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(theme.textPrimary)
-                Text(row.item.note)
-                    .font(.system(size: 10))
-                    .foregroundStyle(theme.textSecondary)
-                    .lineLimit(1)
-            }
+            Text(row.item.name)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(theme.textPrimary)
+                .lineLimit(1)
+                .layoutPriority(2)
 
-            Spacer()
+            Text(row.item.note)
+                .font(.system(size: 10))
+                .foregroundStyle(theme.textSecondary)
+                .lineLimit(1)
+                .layoutPriority(1)
+
+            Spacer(minLength: 8)
 
             Text(row.item.paths.map(abbreviate).joined(separator: " · "))
                 .font(.system(size: 10))
@@ -216,9 +286,11 @@ private struct CleanupRowView: View {
                 .frame(maxWidth: 260, alignment: .trailing)
 
             sizeLabel
-                .frame(width: 90, alignment: .trailing)
+                .frame(width: 80, alignment: .trailing)
         }
-        .padding(.horizontal, 12).padding(.vertical, 8)
+        .padding(.horizontal, 10).padding(.vertical, 5)
+        .contentShape(Rectangle())
+        .onTapGesture { if !disabled && row.size.isSelectable { toggle() } }
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(row.item.name), \(sizeAccessibility)")
     }
@@ -254,14 +326,5 @@ private struct CleanupRowView: View {
     private func abbreviate(_ path: String) -> String {
         let home = NSHomeDirectory()
         return path.hasPrefix(home) ? "~" + path.dropFirst(home.count) : path
-    }
-}
-
-extension CleanupController.SizeState {
-    /// Only measured rows can be selected — a denied or still-sizing row has no
-    /// trustworthy size to confirm against.
-    var isSelectable: Bool {
-        if case .sized = self { return true }
-        return false
     }
 }

--- a/Sources/SpaceMatters/Views/ContentView.swift
+++ b/Sources/SpaceMatters/Views/ContentView.swift
@@ -480,6 +480,9 @@ private struct EmptyState: View {
     @State private var showingRemote = false
 
     private let columns = [GridItem(.adaptive(minimum: 230, maximum: 320), spacing: 14)]
+    /// The disks row uses fixed columns so the cleanup card can be pinned to
+    /// the rightmost one whatever the volume count.
+    private let diskColumns = Array(repeating: GridItem(.flexible(), spacing: 14), count: 3)
 
     var body: some View {
         ScrollView {
@@ -500,10 +503,13 @@ private struct EmptyState: View {
                 if volumes.isEmpty {
                     ProgressView().controlSize(.small)
                 } else {
-                    LazyVGrid(columns: columns, spacing: 14) {
+                    LazyVGrid(columns: diskColumns, spacing: 14) {
                         ForEach(volumes) { volume in
                             VolumeCard(volume: volume, theme: theme) { app.scan(volumes: [volume]) }
                         }
+                        // Spacer cells so the cleanup card lands in the right column.
+                        let pad = (2 - volumes.count % 3 + 3) % 3
+                        ForEach(0..<pad, id: \.self) { _ in Color.clear }
                         CleanupCard(theme: theme) { app.analyzeCleanup() }
                     }
                     .frame(maxWidth: 780)
@@ -644,6 +650,7 @@ private struct VolumeCard: View {
             .font(.system(size: 10).monospacedDigit())
         }
         .padding(14)
+        .frame(height: splashCardHeight, alignment: .top)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("\(volume.name), \(volume.kindLabel)")
         .accessibilityValue("\(percent)% full, \(Format.bytes(volume.used)) used of \(Format.bytes(volume.total))")
@@ -665,35 +672,58 @@ private struct VolumeCard: View {
     private var percent: Int { Int((volume.usedFraction * 100).rounded()) }
 }
 
+/// Shared height of the disk-row splash cards (`VolumeCard`, `CleanupCard`):
+/// the volume stats line can wrap to two lines, so a fixed frame is the only
+/// way to keep the row's cards strictly the same size.
+private let splashCardHeight: CGFloat = 116
+
 /// Splash card for the Low-Hanging Fruits mode: known-safe cleanup (Trash and
-/// well-known dev caches), sitting next to the disks it helps relieve.
+/// well-known dev caches). Mirrors `VolumeCard`'s three-row layout so it lines
+/// up pixel-for-pixel with the disk cards it sits next to; the bar row is an
+/// empty track (nothing measured until the mode opens).
 private struct CleanupCard: View {
     let theme: Theme
     let action: () -> Void
     @State private var hovering = false
 
     var body: some View {
-        HStack(spacing: 10) {
-            Image(systemName: "sparkles")
-                .font(.system(size: 22))
-                .foregroundStyle(theme.accent)
-                .frame(width: 32, height: 32)
-            VStack(alignment: .leading, spacing: 1) {
-                Text("Low-Hanging Fruits")
-                    .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(theme.textPrimary)
-                Text("Safe cleanup · Trash & dev caches")
-                    .font(.system(size: 10, weight: .medium))
-                    .foregroundStyle(theme.textSecondary)
-                    .textCase(.uppercase)
+        VStack(alignment: .leading, spacing: 11) {
+            HStack(spacing: 10) {
+                Image(systemName: "sparkles")
+                    .font(.system(size: 24))
+                    .foregroundStyle(theme.accent)
+                    .frame(width: 32, height: 32)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("Low-Hanging Fruits")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(theme.textPrimary)
+                        .lineLimit(1)
+                    Text("Safe cleanup")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundStyle(theme.textSecondary)
+                        .textCase(.uppercase)
+                }
+                Spacer()
             }
-            Spacer()
-            Image(systemName: "chevron.right")
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(hovering ? theme.accent : theme.textSecondary)
+
+            Capsule().fill(theme.barTrack)
+                .frame(height: 6)
+
+            HStack {
+                Text("Trash · DerivedData · npm · NuGet…")
+                    .foregroundStyle(theme.textSecondary)
+                    .lineLimit(1)
+                Spacer()
+                Label("Analyze", systemImage: "play.fill")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(hovering ? theme.accent : theme.textSecondary)
+            }
+            .font(.system(size: 10).monospacedDigit())
         }
         .padding(14)
-        .accessibilityElement(children: .combine)
+        .frame(height: splashCardHeight, alignment: .top)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Low-Hanging Fruits, safe cleanup")
         .accessibilityHint("Find and empty the Trash and well-known development caches")
         .background(RoundedRectangle(cornerRadius: 12).fill(theme.panelBackground))
         .overlay(RoundedRectangle(cornerRadius: 12)

--- a/Sources/SpaceMatters/Views/ContentView.swift
+++ b/Sources/SpaceMatters/Views/ContentView.swift
@@ -26,6 +26,8 @@ struct ContentView: View {
                 ContainerResultView(controller: app.containers, app: app, isDark: $isDark)
             case .kubernetes:
                 KubernetesResultView(controller: app.kubernetes, app: app, isDark: $isDark)
+            case .cleanup:
+                CleanupResultView(controller: app.cleanup, app: app, isDark: $isDark)
             }
         }
         .environment(\.theme, theme)
@@ -45,6 +47,7 @@ struct ContentView: View {
         case .filesystem: return app.filesystem.rootName.isEmpty ? "SpaceMatters" : app.filesystem.rootName
         case .containers: return app.containers.engineName.isEmpty ? "Containers" : app.containers.engineName
         case .kubernetes: return app.kubernetes.contextName.isEmpty ? "Kubernetes" : app.kubernetes.contextName
+        case .cleanup: return "Low-Hanging Fruits"
         }
     }
 }
@@ -501,6 +504,7 @@ private struct EmptyState: View {
                         ForEach(volumes) { volume in
                             VolumeCard(volume: volume, theme: theme) { app.scan(volumes: [volume]) }
                         }
+                        CleanupCard(theme: theme) { app.analyzeCleanup() }
                     }
                     .frame(maxWidth: 780)
                 }
@@ -659,6 +663,45 @@ private struct VolumeCard: View {
 
     private var usageColor: Color { Theme.usageColor(volume.usedFraction) }
     private var percent: Int { Int((volume.usedFraction * 100).rounded()) }
+}
+
+/// Splash card for the Low-Hanging Fruits mode: known-safe cleanup (Trash and
+/// well-known dev caches), sitting next to the disks it helps relieve.
+private struct CleanupCard: View {
+    let theme: Theme
+    let action: () -> Void
+    @State private var hovering = false
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "sparkles")
+                .font(.system(size: 22))
+                .foregroundStyle(theme.accent)
+                .frame(width: 32, height: 32)
+            VStack(alignment: .leading, spacing: 1) {
+                Text("Low-Hanging Fruits")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(theme.textPrimary)
+                Text("Safe cleanup · Trash & dev caches")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(theme.textSecondary)
+                    .textCase(.uppercase)
+            }
+            Spacer()
+            Image(systemName: "chevron.right")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(hovering ? theme.accent : theme.textSecondary)
+        }
+        .padding(14)
+        .accessibilityElement(children: .combine)
+        .accessibilityHint("Find and empty the Trash and well-known development caches")
+        .background(RoundedRectangle(cornerRadius: 12).fill(theme.panelBackground))
+        .overlay(RoundedRectangle(cornerRadius: 12)
+            .strokeBorder(hovering ? theme.accent : theme.separator, lineWidth: hovering ? 2 : 1))
+        .contentShape(RoundedRectangle(cornerRadius: 12))
+        .onHover { hovering = $0 }
+        .onTapGesture(perform: action)
+    }
 }
 
 /// Splash card that opens the SSH connection form (SPEC-06).

--- a/Tests/SpaceMattersTests/CleanupTests.swift
+++ b/Tests/SpaceMattersTests/CleanupTests.swift
@@ -159,6 +159,36 @@ import Foundation
         #expect(c.totalFound >= 150_000) // nothing was cleaned
     }
 
+    /// Select-all checkbox cycle: none → all → none, and a partial selection
+    /// reads as `.some` and cycles up to `.all`.
+    @Test func toggleAllCyclesTriState() async throws {
+        let (root, cache) = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let cache2 = root.appendingPathComponent("cache2")
+        try FileManager.default.createDirectory(at: cache2, withIntermediateDirectories: true)
+        try Data(count: 4096).write(to: cache2.appendingPathComponent("c.bin"))
+
+        let second = Cleanable(id: "test-cache-2", name: "Second cache", category: "Test",
+                               icon: "shippingbox", note: "fixture", paths: [cache2.path])
+        let c = CleanupController(catalog: [Self.cleanable([cache.path]), second],
+                                  allowedRoot: root.path)
+        c.load()
+        await Self.waitForReady(c)
+
+        #expect(c.selectAllState == .none)
+        c.toggleAll()
+        #expect(c.selectAllState == .all)
+        #expect(c.selectedRows.count == 2)
+
+        c.toggle("test-cache-2")
+        #expect(c.selectAllState == .some)
+        c.toggleAll() // mixed → all
+        #expect(c.selectAllState == .all)
+        c.toggleAll() // all → none
+        #expect(c.selectAllState == .none)
+        #expect(c.selectedRows.isEmpty)
+    }
+
     /// Entries whose paths don't exist disappear; existing ones keep only their
     /// existing paths.
     @Test func detectFiltersMissingPaths() throws {

--- a/Tests/SpaceMattersTests/CleanupTests.swift
+++ b/Tests/SpaceMattersTests/CleanupTests.swift
@@ -1,0 +1,176 @@
+import Testing
+import Foundation
+@testable import SpaceMatters
+
+/// Safety invariants of the Low-Hanging Fruits mode. Cleaning deletes real
+/// files, so every fence is pinned the same way as `DeletionGuardTests`:
+/// contents-only removal, no symlink following, no reach outside the allowed
+/// root, and no cleaning while sizes are still being measured.
+@MainActor
+@Suite struct CleanupTests {
+
+    /// allowedRoot/cache/{a.bin, sub/b.bin} — a fake cache inside a fake home.
+    static func makeFixture() throws -> (root: URL, cache: URL) {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent("sm-cleanup-\(UUID().uuidString)")
+        let cache = root.appendingPathComponent("cache")
+        try fm.createDirectory(at: cache.appendingPathComponent("sub"), withIntermediateDirectories: true)
+        try Data(count: 100_000).write(to: cache.appendingPathComponent("a.bin"))
+        try Data(count: 50_000).write(to: cache.appendingPathComponent("sub/b.bin"))
+        return (root, cache)
+    }
+
+    static func cleanable(_ paths: [String]) -> Cleanable {
+        Cleanable(id: "test-cache", name: "Test cache", category: "Test",
+                  icon: "shippingbox", note: "fixture", paths: paths)
+    }
+
+    static func waitForReady(_ c: CleanupController, timeout: TimeInterval = 5) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while c.state != .ready && Date() < deadline {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.02))
+            await Task.yield()
+        }
+    }
+
+    // MARK: Catalog
+
+    @Test func catalogStaysInsideHome() {
+        let home = NSHomeDirectory()
+        let items = CleanupEngine.catalog()
+        #expect(!items.isEmpty)
+        #expect(Set(items.map(\.id)).count == items.count)
+        for item in items {
+            for path in item.paths {
+                #expect(path.hasPrefix(home + "/"), "\(item.id): \(path) escapes home")
+                #expect(!path.hasSuffix("/"))
+            }
+        }
+    }
+
+    // MARK: Engine
+
+    @Test func sizingMeasuresFixture() throws {
+        let (root, cache) = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let measure = CleanupEngine.size(of: Self.cleanable([cache.path]))
+        guard case .sized(let bytes) = measure else {
+            Issue.record("expected .sized, got \(measure)")
+            return
+        }
+        #expect(bytes >= 150_000) // physical ≥ logical of the two files
+    }
+
+    @Test func cleanRemovesContentsButKeepsRoot() throws {
+        let (root, cache) = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let result = CleanupEngine.clean(Self.cleanable([cache.path]), allowedRoot: root.path)
+        #expect(result.removed == 2) // a.bin + sub (recursively)
+        #expect(result.failed == 0 && result.refused == 0)
+        var isDir: ObjCBool = false
+        #expect(FileManager.default.fileExists(atPath: cache.path, isDirectory: &isDir) && isDir.boolValue)
+        #expect(try FileManager.default.contentsOfDirectory(atPath: cache.path).isEmpty)
+    }
+
+    /// A symlink placed inside a cache must be removed as a link — its target,
+    /// outside the cache, survives.
+    @Test func cleanNeverFollowsSymlinks() throws {
+        let (root, cache) = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let victimDir = root.appendingPathComponent("victim")
+        try FileManager.default.createDirectory(at: victimDir, withIntermediateDirectories: true)
+        try Data(count: 4096).write(to: victimDir.appendingPathComponent("keep.bin"))
+        try FileManager.default.createSymbolicLink(
+            at: cache.appendingPathComponent("link"), withDestinationURL: victimDir)
+
+        _ = CleanupEngine.clean(Self.cleanable([cache.path]), allowedRoot: root.path)
+
+        #expect(!FileManager.default.fileExists(atPath: cache.appendingPathComponent("link").path))
+        #expect(FileManager.default.fileExists(atPath: victimDir.appendingPathComponent("keep.bin").path))
+    }
+
+    /// A cache root that is itself a symlink is refused — never resolved and
+    /// chased to wherever it points.
+    @Test func cleanRefusesSymlinkedRoot() throws {
+        let (root, _) = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let outside = FileManager.default.temporaryDirectory
+            .appendingPathComponent("sm-outside-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: outside) }
+        try FileManager.default.createDirectory(at: outside, withIntermediateDirectories: true)
+        try Data(count: 4096).write(to: outside.appendingPathComponent("keep.bin"))
+        let link = root.appendingPathComponent("linked-cache")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: outside)
+
+        let result = CleanupEngine.clean(Self.cleanable([link.path]), allowedRoot: root.path)
+
+        #expect(result.refused == 1 && result.removed == 0)
+        #expect(FileManager.default.fileExists(atPath: outside.appendingPathComponent("keep.bin").path))
+    }
+
+    /// Paths outside the fence are refused wholesale, whatever the catalog says.
+    @Test func cleanRefusesOutsideFence() throws {
+        let (root, cache) = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let elsewhere = FileManager.default.temporaryDirectory
+            .appendingPathComponent("sm-fence-\(UUID().uuidString)")
+        let result = CleanupEngine.clean(
+            Self.cleanable([cache.path]), allowedRoot: elsewhere.path)
+        #expect(result.refused == 1 && result.removed == 0)
+        #expect(FileManager.default.fileExists(atPath: cache.appendingPathComponent("a.bin").path))
+    }
+
+    // MARK: Controller
+
+    @Test func controllerSizesSelectsAndCleans() async throws {
+        let (root, cache) = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let c = CleanupController(catalog: [Self.cleanable([cache.path])], allowedRoot: root.path)
+        c.load()
+        await Self.waitForReady(c)
+
+        #expect(c.rows.count == 1)
+        #expect(c.totalFound >= 150_000)
+
+        c.toggle("test-cache")
+        #expect(c.totalSelected == c.totalFound)
+
+        await c.cleanSelected()
+        #expect(c.state == .ready)
+        #expect(c.lastFreed >= 150_000)
+        #expect(c.lastFailures == 0)
+        #expect(c.totalFound == 0) // re-measured after cleaning, not assumed
+        #expect(try FileManager.default.contentsOfDirectory(atPath: cache.path).isEmpty)
+    }
+
+    /// Mid-sizing, cleaning is refused — sizes aren't trustworthy yet.
+    @Test func cleanRefusedWhileSizing() async throws {
+        let (root, cache) = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let c = CleanupController(catalog: [Self.cleanable([cache.path])], allowedRoot: root.path)
+        c.load()
+        #expect(c.state == .sizing)
+
+        c.toggle("test-cache")
+        await c.cleanSelected() // refused: still sizing
+        #expect(FileManager.default.fileExists(atPath: cache.appendingPathComponent("a.bin").path))
+
+        await Self.waitForReady(c)
+        #expect(c.totalFound >= 150_000) // nothing was cleaned
+    }
+
+    /// Entries whose paths don't exist disappear; existing ones keep only their
+    /// existing paths.
+    @Test func detectFiltersMissingPaths() throws {
+        let (root, cache) = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let ghost = root.appendingPathComponent("nope").path
+        let detected = CleanupEngine.detect([
+            Self.cleanable([cache.path, ghost]),
+            Cleanable(id: "ghost", name: "Ghost", category: "Test",
+                      icon: "shippingbox", note: "", paths: [ghost]),
+        ])
+        #expect(detected.count == 1)
+        #expect(detected[0].paths == [cache.path])
+    }
+}


### PR DESCRIPTION
## What

A new **Low-Hanging Fruits** mode, Windows-cleanup-style easy wins, reachable from a new splash card sitting right of the disk cards.

- **Catalog (v1, hand-picked, all regenerable)**: Trash · Xcode DerivedData · SwiftPM · CocoaPods · npm · Yarn · pnpm · NuGet · pip · uv · Gradle · Maven · Cargo · go-build · Homebrew downloads. An entry only appears if its path exists on this Mac.
- **Live sizing**: each row fills in as its `getattrlistbulk` walk completes (same walker as the scanner), with a summary strip (found / selected / freed).
- **Explicit cleaning**: nothing pre-selected, a destructive button with confirmation, and freed bytes are **re-measured after cleaning**, not assumed.
- Trash without Full Disk Access shows a "Needs access" deep link to Settings instead of a wrong size.

## Safety model (same spirit as the J4.4 deletion guards)

- Every path is fenced inside the user's home. Anything else is *refused* and surfaced.
- Cleaning removes cache **contents**, never the cache directory itself.
- Symlinks inside a cache are removed as links (target untouched). A cache root that *is* a symlink is refused, never resolved.
- Cleaning is refused while sizing is in flight.

`CleanupTests` (9 tests) pin each of these on real fixtures. The symlink and fence tests assert the would-be victim files actually survive.

## Architecture

Follows the established mode pattern: `CleanupEngine` (Scanner) plus `CleanupController` (ViewModel, ContainerController-style load/refresh/stop with loadID invalidation) plus `CleanupResultView` (Views, same chrome as Containers), routed by `AppModel.Route.cleanup`.

## Not in v1

Browser caches (files held open), blanket `~/Library/Caches`, old Downloads (not regenerable), iOS DeviceSupport and simulators (a candidate for a v2 "Xcode extended" entry). Docker and Podman pruning already lives in the Containers mode.

## Verification

Full suite: 32 tests / 7 suites green. A visual pass on the splash card and mode view is still worth a human look (hover states, light theme).
