### PR TITLE
Gate the "disk changed" banner on a size budget (#14)

### DIFF
--- a/Sources/SpaceMatters/ViewModel/ScanController.swift
+++ b/Sources/SpaceMatters/ViewModel/ScanController.swift
@@ -121,9 +121,22 @@ final class ScanController {
 
     // MARK: Live disk watching (SPEC-04)
 
-    /// True once FSEvents reports a change under the scanned tree — drives the
-    /// "disk changed" banner and the Refresh affordance.
+    /// True once the disk has changed *enough* under the scanned tree to be worth
+    /// surfacing — drives the "disk changed" banner and the Refresh affordance.
+    /// Gated by `diskChangeBudget` so ordinary per-second churn doesn't keep it
+    /// lit (issue #14).
     private(set) var diskChanged = false
+    /// Signed net change in the scanned volume's used space since the current
+    /// result finished — positive means it grew, negative means space was freed.
+    /// Shown in the banner and compared against `diskChangeBudget` to gate it.
+    private(set) var changedBytes: Int64 = 0
+    /// Free bytes on the scanned volume when the result was captured — the
+    /// baseline `changedBytes` is measured against.
+    @ObservationIgnored private var baselineFreeBytes: Int64?
+    /// Last `changedBytes` we repainted for, to avoid needless bumps each batch.
+    @ObservationIgnored private var shownBytes: Int64 = 0
+    /// Minimum absolute net swing before the "disk changed" banner appears.
+    private let diskChangeBudget: Int64 = 128 * 1024 * 1024 // 128 MB
     /// When the current result finished scanning (for "scanned N ago", J5.2).
     private(set) var scanDate: Date?
     /// Paths of the nearest existing nodes touched since the scan — tracked by
@@ -877,18 +890,42 @@ final class ScanController {
         watcher = nil
         dirtyPaths.removeAll()
         diskChanged = false
+        changedBytes = 0
+        shownBytes = 0
+        baselineFreeBytes = nil
     }
 
-    /// FSEvents batch → mark the nearest existing node on each changed path dirty.
+    /// Free bytes on the scanned volume, best-effort. Uses raw `statfs(2)`
+    /// (`f_bavail`, what `df` reports) rather than `volumeAvailableCapacityKey`,
+    /// which folds in macOS "purgeable" space and so doesn't track a write of a
+    /// few hundred MB. `nil` when the root path can't be read.
+    private func volumeFreeBytes() -> Int64? {
+        guard !rootPath.isEmpty else { return nil }
+        var s = statfs()
+        guard statfs(rootPath, &s) == 0 else { return nil }
+        return Int64(s.f_bavail) * Int64(s.f_bsize)
+    }
+
+    /// FSEvents batch → mark the nearest existing node on each changed path dirty,
+    /// then decide whether the change is big enough to raise the banner.
     private func handleDiskChanges(_ paths: [String]) {
         guard isHostScan, phase == .finished else { return }
-        var changed = false
+        var touched = false
         for p in paths {
             guard let node = nearestNode(toPath: p), let np = path(for: node) else { continue }
-            if dirtyPaths.insert(np).inserted { changed = true }
+            if dirtyPaths.insert(np).inserted { touched = true }
         }
-        if changed {
-            diskChanged = true
+        // Gate the banner on net used-space movement so ordinary per-second churn
+        // (logs, caches ticking over) doesn't keep it lit (issue #14). The dirty
+        // dots still track every touched subtree for the targeted Refresh.
+        if let base = baselineFreeBytes, let free = volumeFreeBytes() {
+            changedBytes = base - free
+        }
+        let show = !dirtyPaths.isEmpty && abs(changedBytes) >= diskChangeBudget
+        let repaint = touched || show != diskChanged || (show && changedBytes != shownBytes)
+        diskChanged = show
+        if repaint {
+            shownBytes = changedBytes
             bump() // repaint the dirty dots + banner
         }
     }
@@ -897,7 +934,11 @@ final class ScanController {
     /// Ancestors subsume descendants, so a change deep in an already-dirty parent
     /// is covered by a single re-scan.
     func refreshDirty() async {
-        guard !dirtyPaths.isEmpty else { diskChanged = false; return }
+        guard !dirtyPaths.isEmpty else {
+            diskChanged = false; changedBytes = 0; shownBytes = 0
+            baselineFreeBytes = volumeFreeBytes()
+            return
+        }
         // Keep only the topmost dirty paths (drop any that sit under another).
         let sorted = dirtyPaths.sorted { $0.count < $1.count }
         var roots: [String] = []
@@ -910,6 +951,10 @@ final class ScanController {
             if let node = nearestNode(toPath: p) { await invalidate(subtree: node) }
         }
         scanDate = Date()
+        // Re-baseline the budget so the banner measures drift from *this* refresh.
+        baselineFreeBytes = volumeFreeBytes()
+        changedBytes = 0
+        shownBytes = 0
     }
 
     private func refreshTotals() {
@@ -1028,6 +1073,11 @@ final class ScanController {
                 phase = .finished
                 scanDate = Date()
                 startWatching() // begin watching the disk for changes (SPEC-04)
+                // Capture the budget baseline *after* startWatching — it resets
+                // watch state (including the baseline) on entry (issue #14).
+                baselineFreeBytes = volumeFreeBytes()
+                changedBytes = 0
+                shownBytes = 0
             }
             filesPerSecond = 0
             stopTimer()

--- a/Sources/SpaceMatters/Views/ContentView.swift
+++ b/Sources/SpaceMatters/Views/ContentView.swift
@@ -121,12 +121,21 @@ private struct DiskChangedBanner: View {
     @Environment(\.theme) private var theme
     @State private var refreshing = false
 
+    /// Spell out how much moved, and in which direction, so the banner is a
+    /// signal worth acting on rather than a permanent fixture (issue #14).
+    private static func message(for delta: Int64) -> String {
+        let amount = Format.bytes(abs(delta))
+        return delta >= 0
+            ? "The disk grew by ~\(amount) since this scan."
+            : "The disk freed ~\(amount) since this scan."
+    }
+
     var body: some View {
         HStack(spacing: 10) {
             Image(systemName: "arrow.triangle.2.circlepath")
                 .font(.system(size: 13))
                 .foregroundStyle(theme.accent)
-            Text("The disk changed since this scan.")
+            Text(Self.message(for: controller.changedBytes))
                 .font(.system(size: 11))
                 .foregroundStyle(theme.textPrimary)
             Spacer(minLength: 8)

--- a/Tests/SpaceMattersTests/NavigationTests.swift
+++ b/Tests/SpaceMattersTests/NavigationTests.swift
@@ -218,8 +218,10 @@ import Foundation
     }
 
     /// SPEC-04 end-to-end: after a scan finishes the disk is watched; an external
-    /// write flips `diskChanged`, and `refreshDirty` re-scans the touched subtree
-    /// so the totals catch up. (FSEvents has ~1 s latency, hence the polling.)
+    /// write marks the touched subtree dirty, and `refreshDirty` re-scans it so the
+    /// totals catch up. A small write stays under the banner's size budget, so it
+    /// doesn't raise `diskChanged` (issue #14) — the reliable signal here is
+    /// `dirtyPaths`. (FSEvents has ~1 s latency, hence the polling.)
     @Test func fsEventsMarkDirtyAndRefreshCatchesUp() async throws {
         let fm = FileManager.default
         let root = fm.temporaryDirectory.appendingPathComponent("mds-fse-\(UUID().uuidString)")
@@ -232,17 +234,18 @@ import Foundation
         await Self.waitForScan(c)
         #expect(c.phase == .finished)
         #expect(!c.diskChanged)
+        #expect(c.dirtyPaths.isEmpty)
         let physBefore = c.root!.aggPhysical.load(ordering: .relaxed)
 
-        // External change: a big new file appears under `sub`.
+        // External change: a new file appears under `sub`.
         try Data(count: 200_000).write(to: root.appendingPathComponent("sub/big.new"))
 
-        // Wait (polling, yielding) for FSEvents to flip the flag.
+        // Wait (polling, yielding) for FSEvents to mark the subtree dirty.
         let deadline = Date().addingTimeInterval(10)
-        while !c.diskChanged && Date() < deadline {
+        while c.dirtyPaths.isEmpty && Date() < deadline {
             try await Task.sleep(for: .milliseconds(200))
         }
-        #expect(c.diskChanged, "FSEvents should have reported the change")
+        #expect(!c.dirtyPaths.isEmpty, "FSEvents should have marked the subtree dirty")
 
         await c.refreshDirty()
         #expect(!c.diskChanged)                 // badge cleared


### PR DESCRIPTION
Fixes #14.

## Problem
The "disk changed since this scan" banner flipped on for *any* FSEvents change under the scanned tree. On a live system that is constant (logs, caches and temp files tick over every second), so the banner was effectively permanent and stopped meaning anything.

## Fix
Gate the banner on how much the scanned volume's used space has actually moved, and say how much and which way:

> The disk grew by ~251 MiB since this scan.

- Capture a **baseline** of free bytes when the result lands, re-captured after each Refresh.
- On every FSEvents batch, compare current free bytes to the baseline, and raise the banner only when the absolute delta crosses a **128 MB budget**.
- The per-row **dirty dots still track every touched subtree**, so the targeted Refresh (`invalidate` of just the changed paths) is unchanged. Only the banner is gated.

### Why raw `statfs`, not `URLResourceValues`
`volumeAvailableCapacityKey` folds in macOS "purgeable" space and does not register a few-hundred-MB write (measured: a 200 MB file moved it ~7 MB). Raw `statfs(2)` `f_bavail` (what `df` reports) tracks real writes to the byte and is stable at idle (±3 MB over 20 s).

## Verification
Drove the built app end to end:
- After a scan of Macintosh HD, ordinary churn keeps the banner **hidden** (dirty dot only).
- Writing a 250 MB file brings the banner up: *"The disk grew by ~251 MiB since this scan."*

`swift test` (33 pass) and `swiftlint --strict` green. The SPEC-04 integration test now asserts on `dirtyPaths` (the reliable dirty signal) rather than the now budget-gated `diskChanged`.

## Note
The budget uses whole-volume free space, so for a *sub-folder* host scan unrelated volume activity could contribute. Acceptable given the dominant whole-volume use case, and the banner still requires a change *inside* the scanned tree. The 128 MB threshold is a single named constant, easy to tune.
