### PR TITLE
Release drafter: one changelog section per PR, by priority

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -11,6 +11,9 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 
+# Each PR is collapsed to a single category label by priority in the autolabel
+# job (.github/workflows/release-drafter.yml), so a PR never appears in two
+# sections. Keep this list in the same order as that priority list.
 categories:
   - title: '🚀 Features'
     labels: ['enhancement', 'feature']

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -58,3 +58,33 @@ jobs:
           disable-releaser: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # release-drafter lists a PR under *every* category its labels match, with
+      # no notion of priority — so a PR labelled both `bug` and `documentation`
+      # shows up twice. Collapse to the single highest-priority category label so
+      # each PR lands in exactly one changelog section.
+      - name: Single-category label (priority)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          # Highest → lowest. Mirror this order in release-drafter.yml categories.
+          priority="breaking enhancement feature bug performance documentation ci dependencies"
+          have="$(gh pr view "$PR" --json labels --jq '.labels[].name')"
+          winner=""
+          for p in $priority; do
+            if printf '%s\n' "$have" | grep -qx "$p"; then winner="$p"; break; fi
+          done
+          if [ -z "$winner" ]; then echo "No category label — leaving as-is."; exit 0; fi
+          drop=""
+          for p in $priority; do
+            [ "$p" = "$winner" ] && continue
+            if printf '%s\n' "$have" | grep -qx "$p"; then drop="$drop --remove-label $p"; fi
+          done
+          if [ -n "$drop" ]; then
+            # shellcheck disable=SC2086
+            gh pr edit "$PR" $drop
+            echo "Kept '$winner'; removed:$drop"
+          else
+            echo "Already single-category: '$winner'."
+          fi

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Single-category label (priority)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }} # this job has no checkout; tell gh the repo
           PR: ${{ github.event.pull_request.number }}
         run: |
           # Highest → lowest. Mirror this order in release-drafter.yml categories.


### PR DESCRIPTION
## Problem
release-drafter lists a PR under **every** category its labels match, and has no notion of priority. So a PR labelled both `bug` and `documentation` (a code fix that also tweaks the README, e.g. #13) appeared in **two** sections of the v0.2.0 draft. PRs like #9 (`enhancement` plus `documentation`) and #11 (`bug` plus `documentation`) duplicated the same way.

## Fix
Add a step to the `autolabel` job that collapses a PR's category labels to the **single highest-priority** one:

`breaking > enhancement/feature > bug > performance > documentation > ci > dependencies`

This keeps the rich autolabeling (a PR still gets all its raw labels first) and just resolves the overlap, so each PR lands in exactly one changelog section. Chosen over crippling the `documentation` file-autolabeler, so "a fix that touches a .md" still reads as a fix, not documentation.

## Result (verified against the real merged PRs)
| PR | labels before | kept |
|----|---------------|------|
| #9 screenshots | documentation, enhancement | **enhancement** → Features |
| #10 WebP | documentation | **documentation** |
| #11 Download fix | bug, documentation | **bug** → Bug Fixes |
| #13 toolbar | bug, documentation | **bug** → Bug Fixes |

No duplication. Uncategorized PRs (e.g. #15, no category label) still appear once in the top list, unchanged.

Logic unit-tested locally in bash, and `zizmor --persona=pedantic` passes.

Note: the priority is a single ordered list in the workflow, mirrored by the category order in `release-drafter.yml`, trivial to retune (e.g. if you would rather "Add screenshots" land in Documentation than Features).
