### PR TITLE
GPU treemap rendering with Metal and monotone resize layout (SPEC-09)

### DIFF
--- a/Sources/SpaceMatters/ViewModel/ScanController.swift
+++ b/Sources/SpaceMatters/ViewModel/ScanController.swift
@@ -452,7 +452,7 @@ final class ScanController {
     /// version), like `sortCache`/`fileCache`.
     func treemapLayout(root: FSNode, rect: CGRect, rootFiles: [FileTileInfo]?,
                        needsRegions: Bool = true) -> TreemapLayout.Result {
-        layoutCache.invalidate(metric: metric, version: version)
+        layoutCache.invalidate(metric: metric, version: version, root: root)
         return TreemapLayout.compute(root: root, rect: rect, metric: metric, rootFiles: rootFiles,
                                      cache: layoutCache, needsRegions: needsRegions)
     }

--- a/Sources/SpaceMatters/Views/TreemapLayout.swift
+++ b/Sources/SpaceMatters/Views/TreemapLayout.swift
@@ -40,24 +40,46 @@ enum TreemapLayout {
         var regions: [ObjectIdentifier: CGRect] = [:]
     }
 
-    /// Size-independent layout structure, memoised per node: each node's children
-    /// and file blocks as `Item`s, sorted by weight (descending), with a parallel
-    /// `weights` array. These depend only on the tree and metric — never on the
-    /// rect — so across a resize they're computed once and reused; only the rect
-    /// *placement* (`squarifySorted`) reruns per frame. The model half of the
-    /// layout, held by the controller alongside `sortCache`/`fileCache`.
+    /// The combinatorial layout structure, memoised per node so the map is a
+    /// **continuous (monotone) function of size**. Squarify interleaves *discrete*
+    /// choices (row grouping, row orientation, which children recurse) with
+    /// *continuous* geometry (rects). The discrete choices are what jump under a
+    /// resize — a change in one dimension flips `min(w,h)` and thus every
+    /// `worstRatio` comparison, reorganising the whole tiling. So we freeze the
+    /// discrete choices here (decided once, at a reference rect) and rerun only the
+    /// continuous geometry (`placeRows`) per frame: replaying a fixed row/orientation
+    /// decomposition on any rect tiles it exactly and continuously. The choices are
+    /// rebuilt only when the tree, metric or zoom root changes — never on resize.
+    ///
+    /// Held by the controller alongside `sortCache`/`fileCache`. At the reference
+    /// rect the output is identical to a plain squarify, so the at-rest look is
+    /// unchanged; only *how it changes under resize* differs (smoothly, not jumpily).
     final class Cache {
-        fileprivate var entries: [ObjectIdentifier: (items: [Item], weights: [Double])] = [:]
+        fileprivate final class Entry {
+            let items: [Item]
+            let weights: [Double]
+            /// Discrete decisions, filled the first time this node is laid out.
+            var decided = false
+            var breaks: [Int] = []          // exclusive end index of each squarified row
+            var orientations: [Bool] = []   // per row: spans the height (a vertical column)
+            var recurse: [Bool] = []        // per item: subdivide the subtree (vs a leaf tile)
+            init(items: [Item], weights: [Double]) { self.items = items; self.weights = weights }
+        }
+        fileprivate var entries: [ObjectIdentifier: Entry] = [:]
         private var metric: SizeMetric?
         private var version: UInt64 = .max
+        private var rootID: ObjectIdentifier?
 
-        /// Drop the memo when the tree (version) or metric changed; keep it across
-        /// pure resizes. Mirrors `ScanController.sortCache`'s invalidation.
-        func invalidate(metric: SizeMetric, version: UInt64) {
-            if self.metric != metric || self.version != version {
+        /// Drop the memo when the tree (version), metric or zoom root changed; keep it
+        /// across pure resizes. A changed root matters because a node cached as a small
+        /// sub-region must re-decide its structure when it becomes the full-rect root.
+        func invalidate(metric: SizeMetric, version: UInt64, root: FSNode) {
+            let rid = ObjectIdentifier(root)
+            if self.metric != metric || self.version != version || self.rootID != rid {
                 entries.removeAll(keepingCapacity: true)
                 self.metric = metric
                 self.version = version
+                self.rootID = rid
             }
         }
     }
@@ -66,10 +88,10 @@ enum TreemapLayout {
     /// the root's own-files region is subdivided into individual file tiles
     /// (SPEC-05, B2). Sub-directories always stay aggregated until you zoom in.
     ///
-    /// `cache` memoises the size-independent structure (see `Cache`). Across a
-    /// resize — same tree, changing rect — the sort and item-building are skipped
-    /// and only the rect placement is redone. Pass `nil` for a one-shot layout
-    /// (e.g. tests); a persistent cache must be invalidated via `Cache.invalidate`.
+    /// `cache` memoises the discrete structure (see `Cache`). Across a resize — same
+    /// tree, changing rect — the discrete choices are reused and only the continuous
+    /// geometry is redone, so the layout flows smoothly. Pass `nil` for a one-shot
+    /// layout (e.g. tests); a persistent cache must be invalidated via `Cache.invalidate`.
     /// `needsRegions` builds the per-node bounding-rect map used to outline a
     /// selection. It's only consulted when something is selected, so skip it
     /// otherwise — that's N `ObjectIdentifier`-keyed dict inserts saved on every
@@ -114,18 +136,19 @@ enum TreemapLayout {
     ) {
         if needsRegions { result.regions[ObjectIdentifier(node)] = rect }
 
-        // Too small or too deep → draw as a solid leaf tile.
-        if rect.width < minSide * 2 || rect.height < minSide * 2 || depth >= maxDepth {
+        // Depth cap is structural (size-independent) → monotone-safe to check here.
+        if depth >= maxDepth {
             result.tiles.append(TreemapTile(rect: rect, node: node, depth: depth, isFileBlock: false))
             return
         }
 
         // Size-independent half: build (and cache) this node's sorted items once.
-        let entry: (items: [Item], weights: [Double])
+        let entry: Cache.Entry
         if let cached = cache.entries[ObjectIdentifier(node)] {
             entry = cached
         } else {
-            entry = buildItems(node: node, depth: depth, metric: metric, files: files)
+            let built = buildItems(node: node, depth: depth, metric: metric, files: files)
+            entry = Cache.Entry(items: built.items, weights: built.weights)
             cache.entries[ObjectIdentifier(node)] = entry
         }
 
@@ -134,8 +157,25 @@ enum TreemapLayout {
             return
         }
 
-        // Size-dependent half: place the (already-sorted) items in this rect.
-        let rects = squarifySorted(entry.weights, into: rect)
+        // Discrete half (decided once, at this reference rect): the squarified row
+        // grouping + orientation, and which children recurse (a size threshold on the
+        // reference rects). Frozen so a resize can't reorganise the tiling.
+        if !entry.decided {
+            let decided = decideRows(entry.weights, rect: rect)
+            entry.breaks = decided.breaks
+            entry.orientations = decided.orientations
+            let refRects = placeRows(entry.weights, rect: rect, breaks: entry.breaks, orientations: entry.orientations)
+            entry.recurse = entry.items.indices.map { i in
+                let item = entry.items[i]
+                guard item.file == nil, !item.isFileBlock, item.node.isDirectory else { return false }
+                let r = refRects[i]
+                return r.width >= minSide * 2 && r.height >= minSide * 2
+            }
+            entry.decided = true
+        }
+
+        // Continuous half: place the fixed rows in the current rect. Reruns per frame.
+        let rects = placeRows(entry.weights, rect: rect, breaks: entry.breaks, orientations: entry.orientations)
         for i in entry.items.indices {
             let item = entry.items[i]
             let r = rects[i]
@@ -144,19 +184,19 @@ enum TreemapLayout {
                 result.tiles.append(TreemapTile(rect: r, node: item.node, depth: depth + 1, isFileBlock: false, file: item.file))
             } else if item.isFileBlock || !item.node.isDirectory {
                 result.tiles.append(TreemapTile(rect: r, node: item.node, depth: depth + 1, isFileBlock: item.isFileBlock))
-            } else if r.width < minSide * 2 || r.height < minSide * 2 {
-                if needsRegions { result.regions[ObjectIdentifier(item.node)] = r }
-                result.tiles.append(TreemapTile(rect: r, node: item.node, depth: depth + 1, isFileBlock: false))
-            } else {
+            } else if entry.recurse[i] {
                 // Sub-directories: no file refinement (files: nil) — B2.
                 layout(node: item.node, rect: r, depth: depth + 1, metric: metric, files: nil,
                        minSide: minSide, maxDepth: maxDepth, cache: cache, needsRegions: needsRegions, into: &result)
+            } else {
+                if needsRegions { result.regions[ObjectIdentifier(item.node)] = r }
+                result.tiles.append(TreemapTile(rect: r, node: item.node, depth: depth + 1, isFileBlock: false))
             }
         }
     }
 
-    /// Build a node's size-independent items, sorted by weight (descending) so
-    /// `squarifySorted` can place them without re-sorting on every resize frame.
+    /// Build a node's size-independent items, sorted by weight (descending) so the
+    /// squarify decisions and placement can run without re-sorting on every frame.
     private static func buildItems(
         node: FSNode, depth: Int, metric: SizeMetric, files: [FileTileInfo]?
     ) -> (items: [Item], weights: [Double]) {
@@ -185,21 +225,20 @@ enum TreemapLayout {
         return (items, items.map(\.weight))
     }
 
-    /// Place already-sorted (descending) `weights` inside `rect`, returning one rect
-    /// per weight in the same order. The squarified packing is identical to
-    /// `squarify(_:into:)` — this variant just skips the internal sort because the
-    /// caller pre-sorted, which is the whole point on the resize hot path.
-    static func squarifySorted(_ weights: [Double], into rect: CGRect) -> [CGRect] {
-        var result = [CGRect](repeating: .zero, count: weights.count)
+    /// The discrete squarify pass: greedily group already-sorted `weights` into rows
+    /// and record each row's break index and orientation (does it span the height —
+    /// a vertical column — or the width). No rects; that's `placeRows`. Splitting the
+    /// decision from the geometry is what lets the geometry rerun continuously under
+    /// resize while the decisions stay put.
+    static func decideRows(_ weights: [Double], rect: CGRect) -> (breaks: [Int], orientations: [Bool]) {
+        var breaks: [Int] = []
+        var orientations: [Bool] = []
         let total = weights.reduce(0, +)
-        guard total > 0 else { return result }
+        guard total > 0 else { return (breaks, orientations) }
         let scale = (Double(rect.width) * Double(rect.height)) / total
 
-        var x = Double(rect.minX)
-        var y = Double(rect.minY)
         var w = Double(rect.width)
         var h = Double(rect.height)
-
         var i = 0
         let n = weights.count
         while i < n {
@@ -221,9 +260,41 @@ enum TreemapLayout {
                     break
                 }
             }
-
             let thickness = shorter == 0 ? 0 : rowSum / shorter
-            if w >= h {
+            let spansHeight = w >= h
+            orientations.append(spansHeight)
+            breaks.append(k)
+            if spansHeight { w -= thickness } else { h -= thickness }
+            i = k
+        }
+        return (breaks, orientations)
+    }
+
+    /// The continuous squarify pass: place a *fixed* row decomposition (`breaks` +
+    /// `orientations`) inside `rect`, one rect per weight. Replaying a fixed
+    /// decomposition on any rect pieces it out exactly and continuously — the whole
+    /// point of the split (`decideRows` freezes the shape, this flows the geometry).
+    /// At the rect the decomposition was decided on, the output equals `squarifySorted`.
+    static func placeRows(_ weights: [Double], rect: CGRect, breaks: [Int], orientations: [Bool]) -> [CGRect] {
+        var result = [CGRect](repeating: .zero, count: weights.count)
+        let total = weights.reduce(0, +)
+        guard total > 0 else { return result }
+        let scale = (Double(rect.width) * Double(rect.height)) / total
+
+        var x = Double(rect.minX)
+        var y = Double(rect.minY)
+        var w = Double(rect.width)
+        var h = Double(rect.height)
+
+        var i = 0
+        for row in breaks.indices {
+            let k = breaks[row]
+            let spansHeight = orientations[row]
+            var rowSum = 0.0
+            for m in i..<k { rowSum += weights[m] * scale }
+            let side = spansHeight ? h : w
+            let thickness = side <= 0 ? 0 : rowSum / side
+            if spansHeight {
                 var yy = y
                 for m in i..<k {
                     let len = thickness == 0 ? 0 : (weights[m] * scale) / thickness
@@ -247,67 +318,22 @@ enum TreemapLayout {
         return result
     }
 
+    /// Place already-sorted (descending) `weights` inside `rect` in one shot (decide +
+    /// place). Kept for the one-shot path and tests; the cached resize path uses
+    /// `decideRows` + `placeRows` instead so the decomposition can be frozen.
+    static func squarifySorted(_ weights: [Double], into rect: CGRect) -> [CGRect] {
+        let decided = decideRows(weights, rect: rect)
+        return placeRows(weights, rect: rect, breaks: decided.breaks, orientations: decided.orientations)
+    }
+
     /// Lay out `weights` (any positive scale) inside `rect`, returning one rect
     /// per input in input order.
     static func squarify(_ weights: [Double], into rect: CGRect) -> [CGRect] {
-        var result = [CGRect](repeating: .zero, count: weights.count)
-        let total = weights.reduce(0, +)
-        guard total > 0 else { return result }
-
-        let area = Double(rect.width) * Double(rect.height)
-        let scale = area / total
         let order = weights.indices.sorted { weights[$0] > weights[$1] }
-        let scaled = order.map { weights[$0] * scale }
-
-        var x = Double(rect.minX)
-        var y = Double(rect.minY)
-        var w = Double(rect.width)
-        var h = Double(rect.height)
-
-        var i = 0
-        let n = scaled.count
-        while i < n {
-            let shorter = min(w, h)
-            var rowSum = scaled[i]
-            var rowMax = scaled[i]
-            var rowMin = scaled[i]
-            var k = i + 1
-            while k < n {
-                let v = scaled[k]
-                let withNext = worstRatio(rowSum: rowSum + v, maxV: max(rowMax, v), minV: min(rowMin, v), side: shorter)
-                let without = worstRatio(rowSum: rowSum, maxV: rowMax, minV: rowMin, side: shorter)
-                if withNext <= without {
-                    rowSum += v
-                    rowMax = max(rowMax, v)
-                    rowMin = min(rowMin, v)
-                    k += 1
-                } else {
-                    break
-                }
-            }
-
-            let thickness = shorter == 0 ? 0 : rowSum / shorter
-            if w >= h {
-                var yy = y
-                for m in i..<k {
-                    let len = thickness == 0 ? 0 : scaled[m] / thickness
-                    result[order[m]] = CGRect(x: x, y: yy, width: thickness, height: len)
-                    yy += len
-                }
-                x += thickness
-                w -= thickness
-            } else {
-                var xx = x
-                for m in i..<k {
-                    let len = thickness == 0 ? 0 : scaled[m] / thickness
-                    result[order[m]] = CGRect(x: xx, y: y, width: len, height: thickness)
-                    xx += len
-                }
-                y += thickness
-                h -= thickness
-            }
-            i = k
-        }
+        let sorted = order.map { weights[$0] }
+        let placed = squarifySorted(sorted, into: rect)
+        var result = [CGRect](repeating: .zero, count: weights.count)
+        for (slot, original) in order.enumerated() { result[original] = placed[slot] }
         return result
     }
 

--- a/Sources/SpaceMatters/Views/TreemapMetalRenderer.swift
+++ b/Sources/SpaceMatters/Views/TreemapMetalRenderer.swift
@@ -1,0 +1,252 @@
+import Metal
+import QuartzCore
+import simd
+
+// GPU renderer for the treemap tiles (SPEC-09). The engine is 3D-native from the
+// start — instanced 3D quads, an MVP camera and a depth buffer — but the current
+// view is its *orthographic top-down projection*: flat tiles (height 0) seen from
+// straight above, which is pixel-identical to the old 2D map. Going 3D later is a
+// camera + height change, not a rewrite (SPEC-09 §9).
+//
+// Only the tile *fill* moves to the GPU; layout, colour source, hit-testing and the
+// selection/hover overlay stay where they were. One `drawPrimitives(instanceCount:)`
+// draws every tile in a single call — the answer to "thousands of CPU fillRect".
+
+/// One tile, as uploaded to the GPU. 3D-native: `origin`/`size` carry a Y (height)
+/// axis that is 0 today (flat quad on the XZ ground plane) and becomes `f(size|count)`
+/// when tiles extrude into boxes. Layout matches the MSL `TileInstance` (48 bytes).
+struct TileInstance {
+    /// World position, top-left corner: (x, y=0, z). `w` is padding.
+    var origin: SIMD4<Float>
+    /// Extent: (width, height=0, depth, dim). `dim` (0…1) folds the highlight/search
+    /// dimming into the instance so no second fill pass is needed.
+    var size: SIMD4<Float>
+    /// Straight sRGB RGBA (opaque; alpha = 1).
+    var color: SIMD4<Float>
+}
+
+/// View × projection, as a single matrix. Today an orthographic top-down camera;
+/// swapping in a perspective + orbit camera is all the 3D transition needs on this side.
+struct Camera {
+    var viewProjection: simd_float4x4
+
+    /// Orthographic top-down over a `width`×`height` (points) ground plane, mapping the
+    /// layout's top-left pixel rects exactly onto the drawable: world X 0→W to NDC −1→+1,
+    /// world Z 0→H (top→bottom) to NDC +1→−1. Ortho of flat tiles preserves proportions,
+    /// so the result is iso-visual with the CoreGraphics map. z is a constant mid-depth
+    /// (flat tiles never overlap); the Y column stays 0 until boxes are extruded.
+    static func orthoTopDown(width: Float, height: Float) -> Camera {
+        let w = max(width, 1), h = max(height, 1)
+        let col0 = SIMD4<Float>(2 / w, 0, 0, 0)   // X → clip.x
+        let col1 = SIMD4<Float>(0, 0, 0, 0)       // Y (height) → nothing yet
+        let col2 = SIMD4<Float>(0, -2 / h, 0, 0)  // Z → clip.y (top-left flip)
+        let col3 = SIMD4<Float>(-1, 1, 0.5, 1)    // translation + constant depth
+        return Camera(viewProjection: simd_float4x4(col0, col1, col2, col3))
+    }
+}
+
+/// Uniforms shared by both shader stages. Matches the MSL `Uniforms` (80 bytes).
+private struct Uniforms {
+    var viewProj: simd_float4x4
+    var borderColor: SIMD4<Float>
+}
+
+final class TreemapMetalRenderer {
+    let device: MTLDevice
+    private let queue: MTLCommandQueue
+    private let pipeline: MTLRenderPipelineState
+    private let depthState: MTLDepthStencilState
+
+    // Triple-buffered instance storage: the CPU never rewrites a buffer the GPU is
+    // still reading. Each slot's buffer is grown (never shrunk) to fit the tile count.
+    private static let maxInflight = 3
+    private let inflight = DispatchSemaphore(value: maxInflight)
+    private var instanceBuffers: [MTLBuffer?]
+    private var frameIndex = 0
+
+    private var depthTexture: MTLTexture?
+    private var depthSize = CGSize.zero
+
+    init?() {
+        guard let device = MTLCreateSystemDefaultDevice(),
+              let queue = device.makeCommandQueue() else { return nil }
+
+        // SwiftPM (no Xcode Metal build step) → compile the shader source at launch.
+        guard let library = try? device.makeLibrary(source: Self.shaderSource, options: nil),
+              let vfn = library.makeFunction(name: "treemapVertex"),
+              let ffn = library.makeFunction(name: "treemapFragment") else { return nil }
+
+        let pd = MTLRenderPipelineDescriptor()
+        pd.vertexFunction = vfn
+        pd.fragmentFunction = ffn
+        pd.colorAttachments[0].pixelFormat = .bgra8Unorm   // non-sRGB: store sRGB values as-is → matches CG
+        pd.depthAttachmentPixelFormat = .depth32Float
+        guard let pipeline = try? device.makeRenderPipelineState(descriptor: pd) else { return nil }
+
+        let dsd = MTLDepthStencilDescriptor()
+        dsd.depthCompareFunction = .less
+        dsd.isDepthWriteEnabled = true
+        guard let depthState = device.makeDepthStencilState(descriptor: dsd) else { return nil }
+
+        self.device = device
+        self.queue = queue
+        self.pipeline = pipeline
+        self.depthState = depthState
+        self.instanceBuffers = Array(repeating: nil, count: Self.maxInflight)
+    }
+
+    /// Draw `instances` into `layer` (clearing to `clearColor`). Safe to call with an
+    /// empty array — it just clears, so an empty tree shows the background.
+    func render(into layer: CAMetalLayer, instances: [TileInstance], camera: Camera,
+                clearColor: SIMD4<Float>, borderColor: SIMD4<Float>) {
+        let size = layer.drawableSize
+        guard size.width > 0, size.height > 0 else { return }
+        ensureDepth(size)
+        guard let drawable = layer.nextDrawable() else { return }
+
+        inflight.wait()
+        frameIndex = (frameIndex + 1) % Self.maxInflight
+        let buffer = instances.isEmpty ? nil : ensureInstanceBuffer(slot: frameIndex, count: instances.count)
+        if let buffer {
+            instances.withUnsafeBytes { raw in
+                buffer.contents().copyMemory(from: raw.baseAddress!, byteCount: raw.count)
+            }
+        }
+
+        var uniforms = Uniforms(viewProj: camera.viewProjection, borderColor: borderColor)
+
+        let rpd = MTLRenderPassDescriptor()
+        rpd.colorAttachments[0].texture = drawable.texture
+        rpd.colorAttachments[0].loadAction = .clear
+        rpd.colorAttachments[0].storeAction = .store
+        rpd.colorAttachments[0].clearColor = MTLClearColor(
+            red: Double(clearColor.x), green: Double(clearColor.y), blue: Double(clearColor.z), alpha: 1)
+        rpd.depthAttachment.texture = depthTexture
+        rpd.depthAttachment.loadAction = .clear
+        rpd.depthAttachment.storeAction = .dontCare
+        rpd.depthAttachment.clearDepth = 1
+
+        guard let cmd = queue.makeCommandBuffer(),
+              let enc = cmd.makeRenderCommandEncoder(descriptor: rpd) else {
+            inflight.signal()
+            return
+        }
+        if let buffer {
+            enc.setRenderPipelineState(pipeline)
+            enc.setDepthStencilState(depthState)
+            enc.setVertexBuffer(buffer, offset: 0, index: 0)
+            enc.setVertexBytes(&uniforms, length: MemoryLayout<Uniforms>.stride, index: 1)
+            enc.setFragmentBytes(&uniforms, length: MemoryLayout<Uniforms>.stride, index: 1)
+            // 4-vertex triangle strip (a unit quad), one instance per tile.
+            enc.drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: 4,
+                               instanceCount: instances.count)
+        }
+        enc.endEncoding()
+        cmd.addCompletedHandler { [inflight] _ in inflight.signal() }
+
+        // `presentsWithTransaction` (set on the layer for smooth live-resize): present
+        // synchronously, inside the current CATransaction, so the drawable and the view
+        // bounds update atomically — no lag/tearing behind the window during a drag.
+        if layer.presentsWithTransaction {
+            cmd.commit()
+            cmd.waitUntilScheduled()
+            drawable.present()
+        } else {
+            cmd.present(drawable)
+            cmd.commit()
+        }
+    }
+
+    private func ensureInstanceBuffer(slot: Int, count: Int) -> MTLBuffer? {
+        let needed = count * MemoryLayout<TileInstance>.stride
+        if let buf = instanceBuffers[slot], buf.length >= needed { return buf }
+        // Grow with headroom so a slowly-growing tile count doesn't reallocate every frame.
+        let buf = device.makeBuffer(length: max(needed, 4096), options: .storageModeShared)
+        instanceBuffers[slot] = buf
+        return buf
+    }
+
+    private func ensureDepth(_ size: CGSize) {
+        guard depthTexture == nil || depthSize != size else { return }
+        let d = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .depth32Float,
+            width: max(1, Int(size.width)), height: max(1, Int(size.height)), mipmapped: false)
+        d.usage = .renderTarget
+        d.storageMode = .private
+        depthTexture = device.makeTexture(descriptor: d)
+        depthSize = size
+    }
+
+    // MARK: - Shader (MSL, compiled at launch)
+
+    private static let shaderSource = """
+    #include <metal_stdlib>
+    using namespace metal;
+
+    struct TileInstance {
+        float4 origin;   // x, y(=0), z, _
+        float4 size;     // width, height(=0), depth, dim
+        float4 color;    // sRGB rgba (opaque)
+    };
+    struct Uniforms {
+        float4x4 viewProj;
+        float4   borderColor;
+    };
+    struct VOut {
+        float4 pos [[position]];
+        float2 uv;
+        float2 tileSize;   // on-screen extent in points (width, depth)
+        float  dim;
+        float4 color;
+    };
+
+    // A unit quad from the vertex id (triangle strip 0..3), placed by the instance and
+    // projected by the camera. Today height = 0 → a flat quad on the ground plane.
+    vertex VOut treemapVertex(uint vid [[vertex_id]],
+                              uint iid [[instance_id]],
+                              const device TileInstance* inst [[buffer(0)]],
+                              constant Uniforms& u [[buffer(1)]]) {
+        float fu = float(vid & 1);
+        float fv = float((vid >> 1) & 1);
+        TileInstance t = inst[iid];
+        float3 world = float3(t.origin.x + fu * t.size.x, 0.0, t.origin.z + fv * t.size.z);
+        VOut o;
+        o.pos = u.viewProj * float4(world, 1.0);
+        o.uv = float2(fu, fv);
+        o.tileSize = float2(t.size.x, t.size.z);
+        o.dim = t.size.w;
+        o.color = t.color;
+        return o;
+    }
+
+    // Fill → cushion sheen (light top → dark bottom, 3 stops matching the CG gradient)
+    // → dim (highlight/search) → border. All per-pixel, all free on the GPU.
+    fragment float4 treemapFragment(VOut in [[stage_in]],
+                                    constant Uniforms& u [[buffer(1)]]) {
+        float3 col = in.color.rgb;
+        float minSide = min(in.tileSize.x, in.tileSize.y);
+
+        // Cushion: white a=.16 @0 → 0 @.45 → black a=.20 @1, over the fill. Skip tiny tiles.
+        if (minSide > 6.0) {
+            float v = in.uv.y;
+            float a; float3 sheen;
+            if (v < 0.45) { a = mix(0.16, 0.0, v / 0.45); sheen = float3(1.0); }
+            else          { a = mix(0.0, 0.20, (v - 0.45) / 0.55); sheen = float3(0.0); }
+            col = mix(col, sheen, a);
+        }
+
+        // Dim non-matching tiles (folded into the instance): black at 72%, matching CG.
+        if (in.dim > 0.0) { col = mix(col, float3(0.0), 0.72 * in.dim); }
+
+        // Border: a ~0.6pt anti-aliased edge in the tile's own colour of `treemapBorder`.
+        if (minSide > 3.0) {
+            float2 dpt = min(in.uv, 1.0 - in.uv) * in.tileSize; // distance to nearest edge, points
+            float edge = min(dpt.x, dpt.y);
+            float e = 1.0 - smoothstep(0.1, 1.1, edge);
+            col = mix(col, u.borderColor.rgb, u.borderColor.a * e);
+        }
+
+        return float4(col, 1.0);
+    }
+    """
+}

--- a/Sources/SpaceMatters/Views/TreemapMetalRenderer.swift
+++ b/Sources/SpaceMatters/Views/TreemapMetalRenderer.swift
@@ -64,8 +64,11 @@ final class TreemapMetalRenderer {
     private var instanceBuffers: [MTLBuffer?]
     private var frameIndex = 0
 
+    private let sampleCount: Int
+    private let transientStorage: MTLStorageMode
+    private var msaaTexture: MTLTexture?
     private var depthTexture: MTLTexture?
-    private var depthSize = CGSize.zero
+    private var attachmentSize = CGSize.zero
 
     init?() {
         guard let device = MTLCreateSystemDefaultDevice(),
@@ -76,15 +79,24 @@ final class TreemapMetalRenderer {
               let vfn = library.makeFunction(name: "treemapVertex"),
               let ffn = library.makeFunction(name: "treemapFragment") else { return nil }
 
+        // 4× MSAA smooths the tile seams so they don't shimmer as fractional edges crawl
+        // across the pixel grid during a live resize. Near-free on Apple Silicon (TBDR:
+        // memoryless samples resolved in-tile). Falls back to 1× where unsupported.
+        let sc = device.supportsTextureSampleCount(4) ? 4 : 1
+        let transient: MTLStorageMode = device.supportsFamily(.apple2) ? .memoryless : .private
+
         let pd = MTLRenderPipelineDescriptor()
         pd.vertexFunction = vfn
         pd.fragmentFunction = ffn
         pd.colorAttachments[0].pixelFormat = .bgra8Unorm   // non-sRGB: store sRGB values as-is → matches CG
         pd.depthAttachmentPixelFormat = .depth32Float
+        pd.sampleCount = sc
         guard let pipeline = try? device.makeRenderPipelineState(descriptor: pd) else { return nil }
 
+        // Coplanar flat tiles never overlap, so `.lessEqual` (equal-z samples pass,
+        // painter's order wins) avoids MSAA seam rejection; ready for real depth in 3D.
         let dsd = MTLDepthStencilDescriptor()
-        dsd.depthCompareFunction = .less
+        dsd.depthCompareFunction = .lessEqual
         dsd.isDepthWriteEnabled = true
         guard let depthState = device.makeDepthStencilState(descriptor: dsd) else { return nil }
 
@@ -92,6 +104,8 @@ final class TreemapMetalRenderer {
         self.queue = queue
         self.pipeline = pipeline
         self.depthState = depthState
+        self.sampleCount = sc
+        self.transientStorage = transient
         self.instanceBuffers = Array(repeating: nil, count: Self.maxInflight)
     }
 
@@ -101,7 +115,7 @@ final class TreemapMetalRenderer {
                 clearColor: SIMD4<Float>, borderColor: SIMD4<Float>) {
         let size = layer.drawableSize
         guard size.width > 0, size.height > 0 else { return }
-        ensureDepth(size)
+        ensureAttachments(size)
         guard let drawable = layer.nextDrawable() else { return }
 
         inflight.wait()
@@ -116,9 +130,16 @@ final class TreemapMetalRenderer {
         var uniforms = Uniforms(viewProj: camera.viewProjection, borderColor: borderColor)
 
         let rpd = MTLRenderPassDescriptor()
-        rpd.colorAttachments[0].texture = drawable.texture
+        if sampleCount > 1 {
+            // Render into the MSAA texture, resolve down into the drawable on store.
+            rpd.colorAttachments[0].texture = msaaTexture
+            rpd.colorAttachments[0].resolveTexture = drawable.texture
+            rpd.colorAttachments[0].storeAction = .multisampleResolve
+        } else {
+            rpd.colorAttachments[0].texture = drawable.texture
+            rpd.colorAttachments[0].storeAction = .store
+        }
         rpd.colorAttachments[0].loadAction = .clear
-        rpd.colorAttachments[0].storeAction = .store
         rpd.colorAttachments[0].clearColor = MTLClearColor(
             red: Double(clearColor.x), green: Double(clearColor.y), blue: Double(clearColor.z), alpha: 1)
         rpd.depthAttachment.texture = depthTexture
@@ -166,15 +187,28 @@ final class TreemapMetalRenderer {
         return buf
     }
 
-    private func ensureDepth(_ size: CGSize) {
-        guard depthTexture == nil || depthSize != size else { return }
-        let d = MTLTextureDescriptor.texture2DDescriptor(
-            pixelFormat: .depth32Float,
-            width: max(1, Int(size.width)), height: max(1, Int(size.height)), mipmapped: false)
-        d.usage = .renderTarget
-        d.storageMode = .private
-        depthTexture = device.makeTexture(descriptor: d)
-        depthSize = size
+    private func ensureAttachments(_ size: CGSize) {
+        guard depthTexture == nil || attachmentSize != size else { return }
+        let w = max(1, Int(size.width)), h = max(1, Int(size.height))
+
+        let dd = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .depth32Float, width: w, height: h, mipmapped: false)
+        dd.textureType = sampleCount > 1 ? .type2DMultisample : .type2D
+        dd.sampleCount = sampleCount
+        dd.usage = .renderTarget
+        dd.storageMode = transientStorage
+        depthTexture = device.makeTexture(descriptor: dd)
+
+        if sampleCount > 1 {
+            let cd = MTLTextureDescriptor.texture2DDescriptor(
+                pixelFormat: .bgra8Unorm, width: w, height: h, mipmapped: false)
+            cd.textureType = .type2DMultisample
+            cd.sampleCount = sampleCount
+            cd.usage = .renderTarget
+            cd.storageMode = transientStorage
+            msaaTexture = device.makeTexture(descriptor: cd)
+        }
+        attachmentSize = size
     }
 
     // MARK: - Shader (MSL, compiled at launch)

--- a/Sources/SpaceMatters/Views/TreemapView.swift
+++ b/Sources/SpaceMatters/Views/TreemapView.swift
@@ -128,8 +128,6 @@ final class TreemapNSView: NSView, CALayerDelegate {
     private var tiles: [TreemapTile] = []
     private var colors: [CGColor] = []            // CG fallback path
     private var instances: [TileInstance] = []    // Metal path (culled to visible tiles)
-    private var layoutRect: CGRect = .zero        // inset rect `tiles` were squarified in
-    private var colorDenom: Double = 1            // max tile size at last full layout
     private var regions: [ObjectIdentifier: CGRect] = [:]
     private var regionsBuilt = false
     private var hovered: TreemapTile?
@@ -268,14 +266,8 @@ final class TreemapNSView: NSView, CALayerDelegate {
 
     override func viewDidEndLiveResize() {
         super.viewDidEndLiveResize()
-        guard renderer != nil else {
-            setScale(window?.backingScaleFactor ?? 2)   // fallback: restore crisp backing scale
-            return
-        }
-        // Re-settle the frozen, stretched layout into a proper squarified one at the final size.
-        relayout()
-        presentTiles()
-        overlayLayer.setNeedsDisplay()
+        guard renderer == nil else { return }
+        setScale(window?.backingScaleFactor ?? 2)
     }
 
     // MARK: SwiftUI → view
@@ -349,16 +341,10 @@ final class TreemapNSView: NSView, CALayerDelegate {
         } else {
             tileLayer.frame = bounds
         }
-        // Squarify is not monotone under resize: recomputing it every frame reorganises the
-        // tiles wholesale (the flicker). During a live drag, keep the layout FROZEN and just
-        // affine-scale the existing tiles into the new bounds — spatially stable, tiles only
-        // stretch (a pure ortho-camera rescale). A full squarified relayout re-settles when
-        // the drag ends (viewDidEndLiveResize).
-        if renderer != nil, inLiveResize, !tiles.isEmpty, layoutRect.width > 0, layoutRect.height > 0 {
-            packInstances(denom: colorDenom, from: layoutRect, to: bounds.insetBy(dx: 1, dy: 1))
-        } else {
-            relayout()
-        }
+        // The squarified layout is now monotone under resize (TreemapLayout freezes the
+        // discrete row/orientation/recurse decisions and reruns only continuous geometry),
+        // so a full relayout every frame flows smoothly — no freeze/settle needed.
+        relayout()
         presentTiles()
         overlayLayer.setNeedsDisplay()
     }
@@ -369,11 +355,10 @@ final class TreemapNSView: NSView, CALayerDelegate {
         hovered = nil
         guard let controller, let zoomRoot, bounds.width > 1, bounds.height > 1 else {
             tiles = []; colors.removeAll(keepingCapacity: true); instances.removeAll(keepingCapacity: true)
-            regions = [:]; regionsBuilt = false; layoutRect = .zero
+            regions = [:]; regionsBuilt = false
             return
         }
         let rect = bounds.insetBy(dx: 1, dy: 1)
-        layoutRect = rect
         let rootFiles = rootFileTiles(for: zoomRoot, controller: controller)
         let needRegions = selection != nil
         let result = controller.treemapLayout(root: zoomRoot, rect: rect, rootFiles: rootFiles,
@@ -404,9 +389,8 @@ final class TreemapNSView: NSView, CALayerDelegate {
             if s > maxSize { maxSize = s }
         }
         let denom = Double(maxSize)
-        colorDenom = denom
         if renderer != nil {
-            packInstances(denom: denom, from: layoutRect, to: layoutRect)
+            packInstances(denom: denom)
         } else {
             colors.removeAll(keepingCapacity: true)
             colors.reserveCapacity(n)
@@ -420,33 +404,16 @@ final class TreemapNSView: NSView, CALayerDelegate {
     /// Pack `tiles` into GPU `instances` (Metal path): world rect on the ground plane
     /// (top-left, height 0), packed sRGB colour, dim folded in. Sub-pixel tiles are
     /// culled here — `instances` may be shorter than `tiles`; hit-testing uses `tiles`.
-    ///
-    /// The tile rects were squarified in `src`; they are affine-mapped into `dst`. For a
-    /// full layout `src == dst` (identity). During a live resize the squarified layout is
-    /// frozen (`src` = the layout rect) and stretched into the new bounds (`dst`) instead
-    /// of re-running the non-monotone squarify every frame — a pure ortho-camera rescale.
-    private func packInstances(denom: Double, from src: CGRect, to dst: CGRect) {
+    private func packInstances(denom: Double) {
         let n = tiles.count
         instances.removeAll(keepingCapacity: true)
         instances.reserveCapacity(n)
-        let sx = src.width > 0 ? Double(dst.width) / Double(src.width) : 1
-        let sy = src.height > 0 ? Double(dst.height) / Double(src.height) : 1
-        let identity = sx == 1 && sy == 1 && src.origin == dst.origin
         let highlightName = selectedExt?.displayName
         let hasSearch = highlightName == nil && !searchMatchIDs.isEmpty
         for i in 0..<n {
             let tile = tiles[i]
-            let r0 = tile.rect
-            let x: Double, y: Double, w: Double, h: Double
-            if identity {
-                x = Double(r0.minX); y = Double(r0.minY); w = Double(r0.width); h = Double(r0.height)
-            } else {
-                x = Double(dst.minX) + (Double(r0.minX) - Double(src.minX)) * sx
-                y = Double(dst.minY) + (Double(r0.minY) - Double(src.minY)) * sy
-                w = Double(r0.width) * sx
-                h = Double(r0.height) * sy
-            }
-            if w <= 0.5 || h <= 0.5 { continue }
+            let r = tile.rect
+            if r.width <= 0.5 || r.height <= 0.5 { continue }
             let weight = min(1.0, max(0.0, pow(Double(sizeScratch[i]) / denom, 0.40)))
             var dim: Float = 0
             if let highlightName {
@@ -456,8 +423,8 @@ final class TreemapNSView: NSView, CALayerDelegate {
                 dim = 1
             }
             instances.append(TileInstance(
-                origin: SIMD4<Float>(Float(x), 0, Float(y), 0),
-                size: SIMD4<Float>(Float(w), 0, Float(h), dim),
+                origin: SIMD4<Float>(Float(r.minX), 0, Float(r.minY), 0),
+                size: SIMD4<Float>(Float(r.width), 0, Float(r.height), dim),
                 color: floatColor(for: tile, weight: weight)))
         }
     }

--- a/Sources/SpaceMatters/Views/TreemapView.swift
+++ b/Sources/SpaceMatters/Views/TreemapView.swift
@@ -199,17 +199,21 @@ final class TreemapNSView: NSView, CALayerDelegate {
         }
         super.init(frame: frameRect)
         wantsLayer = true
-        layerContentsRedrawPolicy = .duringViewResize
+        // Metal path: the CAMetalLayer is the view's *backing* layer (see makeBackingLayer),
+        // so AppKit resizes it in lockstep with the view — no sublayer-frame lag / black
+        // bands during a live drag. The overlay is a sublayer above it. AppKit must not try
+        // to CG-redraw the metal layer, so its content-redraw policy is `.never`.
+        layerContentsRedrawPolicy = renderer == nil ? .duringViewResize : .never
         layer?.masksToBounds = true
 
-        // Metal draws itself (no CALayerDelegate); the CG fallback layer uses `draw`.
         if metalLayer == nil {
+            // Fallback: a CG-rendered tile sublayer under the overlay.
             tileLayer.delegate = self
             tileLayer.needsDisplayOnBoundsChange = true
             tileLayer.contentsScale = 2
+            tileLayer.frame = bounds
+            layer?.addSublayer(tileLayer)
         }
-        tileLayer.frame = bounds
-        layer?.addSublayer(tileLayer)
 
         overlayLayer.delegate = self
         overlayLayer.needsDisplayOnBoundsChange = true
@@ -218,6 +222,12 @@ final class TreemapNSView: NSView, CALayerDelegate {
         layer?.addSublayer(overlayLayer)
 
         rebuildThemeColors()   // seed background/border (CG + Metal comps) from the default theme
+    }
+
+    /// Metal path: hand AppKit the `CAMetalLayer` as the backing layer, so it's resized in
+    /// lockstep with the view — the fix for resize lag / black bands. Fallback: default layer.
+    override func makeBackingLayer() -> CALayer {
+        metalLayer ?? super.makeBackingLayer()
     }
 
     @available(*, unavailable)
@@ -323,11 +333,13 @@ final class TreemapNSView: NSView, CALayerDelegate {
         let changed = newSize != frame.size
         super.setFrameSize(newSize)
         guard changed else { return }
-        tileLayer.frame = bounds
         overlayLayer.frame = bounds
         if let metalLayer {
+            // Backing-layer frame is managed by AppKit; we only resize the drawable + redraw.
             let scale = window?.backingScaleFactor ?? 2
             metalLayer.drawableSize = CGSize(width: bounds.width * scale, height: bounds.height * scale)
+        } else {
+            tileLayer.frame = bounds
         }
         relayout()
         presentTiles()
@@ -500,7 +512,7 @@ final class TreemapNSView: NSView, CALayerDelegate {
         // The layer context is native Core Graphics: bottom-left, y-up, text upright.
         // The tile rects are top-left, so each is flipped into this space at draw time
         // (`flip`). No context or text-matrix flips — so glyphs can never mirror.
-        if layer === tileLayer {
+        if layer === tileLayer, renderer == nil {
             drawTiles(in: ctx, height: layer.bounds.height)
         } else if layer === overlayLayer {
             drawOverlay(in: ctx, size: layer.bounds.size)

--- a/Sources/SpaceMatters/Views/TreemapView.swift
+++ b/Sources/SpaceMatters/Views/TreemapView.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 import AppKit
+import Metal
+import QuartzCore
 
 /// Treemap view. The map itself is drawn by a plain AppKit `NSView`
 /// (`TreemapNSView`) rather than a SwiftUI `Canvas`, so a window resize is driven
@@ -124,13 +126,18 @@ final class TreemapNSView: NSView, CALayerDelegate {
 
     // Layout state.
     private var tiles: [TreemapTile] = []
-    private var colors: [CGColor] = []
+    private var colors: [CGColor] = []            // CG fallback path
+    private var instances: [TileInstance] = []    // Metal path (culled to visible tiles)
     private var regions: [ObjectIdentifier: CGRect] = [:]
     private var regionsBuilt = false
     private var hovered: TreemapTile?
 
-    // Layers: tiles (cached) and overlay (hover/selection).
-    private let tileLayer = CALayer()
+    // Tile layer: a `CAMetalLayer` when a GPU is available (the fast path — SPEC-09),
+    // else a plain `CALayer` rasterised by CoreGraphics (defensive fallback). The
+    // selection/hover overlay stays a CG layer above it (Phase 1).
+    private let tileLayer: CALayer
+    private let metalLayer: CAMetalLayer?
+    private let renderer: TreemapMetalRenderer?
     private let overlayLayer = CALayer()
 
     // MARK: Caches (persist across relayouts)
@@ -139,6 +146,7 @@ final class TreemapNSView: NSView, CALayerDelegate {
     private let paletteCount = Theme.paletteHues.count
     private var hueIndexCache: [ObjectIdentifier: Int] = [:]
     private var colorLUT: [CGColor?] = []
+    private var colorLUTf: [SIMD4<Float>?] = []
     private var colorKey: ColorKey?
     private var sizeScratch: [Int64] = []
 
@@ -149,6 +157,9 @@ final class TreemapNSView: NSView, CALayerDelegate {
     private var backgroundCG = CGColor(gray: 0, alpha: 1)
     private var borderCG = CGColor(gray: 0, alpha: 0.45)
     private var accentShadowCG = CGColor(gray: 0.3, alpha: 0.9)
+    // Theme-derived sRGB components for the Metal clear + border uniform.
+    private var backgroundComps = SIMD4<Float>(0, 0, 0, 1)
+    private var borderComps = SIMD4<Float>(0, 0, 0, 0.45)
     private static let dimCG = CGColor(gray: 0, alpha: 0.72)
     private static let spotlightDimCG = CGColor(gray: 0, alpha: 0.5)
     private static let blackBorderCG = CGColor(gray: 0, alpha: 0.85)
@@ -170,17 +181,43 @@ final class TreemapNSView: NSView, CALayerDelegate {
     // MARK: Setup
 
     override init(frame frameRect: NSRect) {
+        if let renderer = TreemapMetalRenderer() {
+            let ml = CAMetalLayer()
+            ml.device = renderer.device
+            ml.pixelFormat = .bgra8Unorm            // non-sRGB: store sRGB values as-is → matches CG
+            ml.framebufferOnly = true
+            ml.isOpaque = true
+            ml.presentsWithTransaction = true       // atomic present with bounds during live-resize
+            ml.colorspace = CGColorSpace(name: CGColorSpace.sRGB)
+            self.renderer = renderer
+            self.metalLayer = ml
+            self.tileLayer = ml
+        } else {
+            self.renderer = nil
+            self.metalLayer = nil
+            self.tileLayer = CALayer()
+        }
         super.init(frame: frameRect)
         wantsLayer = true
         layerContentsRedrawPolicy = .duringViewResize
         layer?.masksToBounds = true
-        for sub in [tileLayer, overlayLayer] {
-            sub.delegate = self
-            sub.needsDisplayOnBoundsChange = true
-            sub.contentsScale = 2
-            sub.frame = bounds
-            layer?.addSublayer(sub)
+
+        // Metal draws itself (no CALayerDelegate); the CG fallback layer uses `draw`.
+        if metalLayer == nil {
+            tileLayer.delegate = self
+            tileLayer.needsDisplayOnBoundsChange = true
+            tileLayer.contentsScale = 2
         }
+        tileLayer.frame = bounds
+        layer?.addSublayer(tileLayer)
+
+        overlayLayer.delegate = self
+        overlayLayer.needsDisplayOnBoundsChange = true
+        overlayLayer.contentsScale = 2
+        overlayLayer.frame = bounds
+        layer?.addSublayer(overlayLayer)
+
+        rebuildThemeColors()   // seed background/border (CG + Metal comps) from the default theme
     }
 
     @available(*, unavailable)
@@ -195,24 +232,31 @@ final class TreemapNSView: NSView, CALayerDelegate {
     }
 
     private func setScale(_ scale: CGFloat) {
-        tileLayer.contentsScale = scale
+        if let metalLayer {
+            metalLayer.contentsScale = scale
+            metalLayer.drawableSize = CGSize(width: bounds.width * scale, height: bounds.height * scale)
+            presentTiles()
+        } else {
+            tileLayer.contentsScale = scale
+            tileLayer.setNeedsDisplay()
+        }
         overlayLayer.contentsScale = scale
-        tileLayer.setNeedsDisplay()
         overlayLayer.setNeedsDisplay()
     }
 
-    // The map is CPU-rasterised into the layer, and filling the big solid tiles at 2×
-    // retina is the resize bottleneck (memory bandwidth). During a live drag, fill ¼
-    // the pixels (1× backing) — slightly soft while dragging, re-rendered crisp the
-    // instant the drag ends. Motion hides the softness; the still frame stays sharp.
+    // Fallback (no-GPU) path only: CPU rasterisation of the big solid tiles at 2× retina
+    // is the resize bottleneck, so during a live drag we fill ¼ the pixels (1× backing)
+    // and re-render crisp when it ends. Metal renders full-res cheaply — it skips this.
     override func viewWillStartLiveResize() {
         super.viewWillStartLiveResize()
+        guard renderer == nil else { return }
         tileLayer.contentsScale = 1
         overlayLayer.contentsScale = 1
     }
 
     override func viewDidEndLiveResize() {
         super.viewDidEndLiveResize()
+        guard renderer == nil else { return }
         setScale(window?.backingScaleFactor ?? 2)
     }
 
@@ -244,14 +288,15 @@ final class TreemapNSView: NSView, CALayerDelegate {
 
         if structural {
             relayout()
-            tileLayer.setNeedsDisplay()
+            presentTiles()
             overlayLayer.setNeedsDisplay()
         } else {
             if selectionChanged && selection != nil && !regionsBuilt {
                 relayout()               // need the region map to outline the new selection
-                tileLayer.setNeedsDisplay()
+                presentTiles()
             } else if highlightChanged {
-                tileLayer.setNeedsDisplay()   // dimming changed; rects unchanged
+                computeColors()          // dimming changed; rects unchanged → repack (Metal folds dim in)
+                presentTiles()
             }
             if selectionChanged { overlayLayer.setNeedsDisplay() }
         }
@@ -262,6 +307,14 @@ final class TreemapNSView: NSView, CALayerDelegate {
         borderCG = NSColor(theme.treemapBorder).cgColor
         accentShadowCG = NSColor(theme.accent).withAlphaComponent(0.9).cgColor
         layer?.backgroundColor = backgroundCG
+        backgroundComps = srgbComps(theme.treemapBackground)
+        borderComps = srgbComps(theme.treemapBorder)
+    }
+
+    private func srgbComps(_ color: Color) -> SIMD4<Float> {
+        let ns = NSColor(color).usingColorSpace(.sRGB) ?? NSColor(color)
+        return SIMD4<Float>(Float(ns.redComponent), Float(ns.greenComponent),
+                            Float(ns.blueComponent), Float(ns.alphaComponent))
     }
 
     // MARK: Resize (AppKit-driven — the hot path)
@@ -272,8 +325,12 @@ final class TreemapNSView: NSView, CALayerDelegate {
         guard changed else { return }
         tileLayer.frame = bounds
         overlayLayer.frame = bounds
+        if let metalLayer {
+            let scale = window?.backingScaleFactor ?? 2
+            metalLayer.drawableSize = CGSize(width: bounds.width * scale, height: bounds.height * scale)
+        }
         relayout()
-        tileLayer.setNeedsDisplay()
+        presentTiles()
         overlayLayer.setNeedsDisplay()
     }
 
@@ -282,7 +339,8 @@ final class TreemapNSView: NSView, CALayerDelegate {
     private func relayout() {
         hovered = nil
         guard let controller, let zoomRoot, bounds.width > 1, bounds.height > 1 else {
-            tiles = []; colors.removeAll(keepingCapacity: true); regions = [:]; regionsBuilt = false
+            tiles = []; colors.removeAll(keepingCapacity: true); instances.removeAll(keepingCapacity: true)
+            regions = [:]; regionsBuilt = false
             return
         }
         let rect = bounds.insetBy(dx: 1, dy: 1)
@@ -305,6 +363,7 @@ final class TreemapNSView: NSView, CALayerDelegate {
         if colorKey != key {
             hueIndexCache.removeAll(keepingCapacity: true)
             colorLUT = Array(repeating: nil, count: paletteCount * Self.brightnessBuckets)
+            colorLUTf = Array(repeating: nil, count: paletteCount * Self.brightnessBuckets)
             colorKey = key
         }
         if sizeScratch.count < n { sizeScratch = [Int64](repeating: 0, count: n) }
@@ -315,11 +374,43 @@ final class TreemapNSView: NSView, CALayerDelegate {
             if s > maxSize { maxSize = s }
         }
         let denom = Double(maxSize)
-        colors.removeAll(keepingCapacity: true)
-        colors.reserveCapacity(n)
+        if renderer != nil {
+            packInstances(denom: denom)
+        } else {
+            colors.removeAll(keepingCapacity: true)
+            colors.reserveCapacity(n)
+            for i in 0..<n {
+                let weight = min(1.0, max(0.0, pow(Double(sizeScratch[i]) / denom, 0.40)))
+                colors.append(cgColor(for: tiles[i], weight: weight))
+            }
+        }
+    }
+
+    /// Pack `tiles` into GPU `instances` (Metal path): world rect on the ground plane
+    /// (top-left, height 0), packed sRGB colour, dim folded in. Sub-pixel tiles are
+    /// culled here — `instances` may be shorter than `tiles`; hit-testing uses `tiles`.
+    private func packInstances(denom: Double) {
+        let n = tiles.count
+        instances.removeAll(keepingCapacity: true)
+        instances.reserveCapacity(n)
+        let highlightName = selectedExt?.displayName
+        let hasSearch = highlightName == nil && !searchMatchIDs.isEmpty
         for i in 0..<n {
+            let tile = tiles[i]
+            let r = tile.rect
+            if r.width <= 0.5 || r.height <= 0.5 { continue }
             let weight = min(1.0, max(0.0, pow(Double(sizeScratch[i]) / denom, 0.40)))
-            colors.append(cgColor(for: tiles[i], weight: weight))
+            var dim: Float = 0
+            if let highlightName {
+                let tileExt = tile.file?.extName ?? tile.node.dominantExt.displayName
+                if tileExt != highlightName { dim = 1 }
+            } else if hasSearch, !isUnderMatch(tile.node) {
+                dim = 1
+            }
+            instances.append(TileInstance(
+                origin: SIMD4<Float>(Float(r.minX), 0, Float(r.minY), 0),
+                size: SIMD4<Float>(Float(r.width), 0, Float(r.height), dim),
+                color: floatColor(for: tile, weight: weight)))
         }
     }
 
@@ -343,6 +434,43 @@ final class TreemapNSView: NSView, CALayerDelegate {
             hueIndex: hueIdx, weight: (Double(bucket) + 0.5) / Double(Self.brightnessBuckets))).cgColor
         colorLUT[lutKey] = color
         return color
+    }
+
+    /// sRGB RGBA for a tile (Metal path), memoised in the same `(hueIndex, bucket)` LUT
+    /// shape as `cgColor` — no per-frame `NSColor`/hashing on the resize hot path.
+    private func floatColor(for tile: TreemapTile, weight: Double) -> SIMD4<Float> {
+        let hueIdx: Int
+        if let ext = tile.file?.extName {
+            hueIdx = Theme.stableIndex(ext, paletteCount)
+        } else {
+            let oid = ObjectIdentifier(tile.node)
+            if let cached = hueIndexCache[oid] {
+                hueIdx = cached
+            } else {
+                hueIdx = Theme.stableIndex(tile.node.dominantExt.displayName, paletteCount)
+                hueIndexCache[oid] = hueIdx
+            }
+        }
+        let bucket = min(Self.brightnessBuckets - 1, Int(weight * Double(Self.brightnessBuckets)))
+        let lutKey = hueIdx * Self.brightnessBuckets + bucket
+        if let cached = colorLUTf[lutKey] { return cached }
+        let ns = NSColor(theme.treemapTypeColor(
+            hueIndex: hueIdx, weight: (Double(bucket) + 0.5) / Double(Self.brightnessBuckets)))
+        let s = ns.usingColorSpace(.sRGB) ?? ns
+        let v = SIMD4<Float>(Float(s.redComponent), Float(s.greenComponent), Float(s.blueComponent), 1)
+        colorLUTf[lutKey] = v
+        return v
+    }
+
+    /// Push the current tiles to screen: a GPU render (Metal) or a layer redraw (CG).
+    private func presentTiles() {
+        if let renderer, let metalLayer {
+            renderer.render(into: metalLayer, instances: instances,
+                            camera: Camera.orthoTopDown(width: Float(bounds.width), height: Float(bounds.height)),
+                            clearColor: backgroundComps, borderColor: borderComps)
+        } else {
+            tileLayer.setNeedsDisplay()
+        }
     }
 
     private func tileSize(_ tile: TreemapTile) -> Int64 {

--- a/Sources/SpaceMatters/Views/TreemapView.swift
+++ b/Sources/SpaceMatters/Views/TreemapView.swift
@@ -128,6 +128,8 @@ final class TreemapNSView: NSView, CALayerDelegate {
     private var tiles: [TreemapTile] = []
     private var colors: [CGColor] = []            // CG fallback path
     private var instances: [TileInstance] = []    // Metal path (culled to visible tiles)
+    private var layoutRect: CGRect = .zero        // inset rect `tiles` were squarified in
+    private var colorDenom: Double = 1            // max tile size at last full layout
     private var regions: [ObjectIdentifier: CGRect] = [:]
     private var regionsBuilt = false
     private var hovered: TreemapTile?
@@ -266,8 +268,14 @@ final class TreemapNSView: NSView, CALayerDelegate {
 
     override func viewDidEndLiveResize() {
         super.viewDidEndLiveResize()
-        guard renderer == nil else { return }
-        setScale(window?.backingScaleFactor ?? 2)
+        guard renderer != nil else {
+            setScale(window?.backingScaleFactor ?? 2)   // fallback: restore crisp backing scale
+            return
+        }
+        // Re-settle the frozen, stretched layout into a proper squarified one at the final size.
+        relayout()
+        presentTiles()
+        overlayLayer.setNeedsDisplay()
     }
 
     // MARK: SwiftUI → view
@@ -341,7 +349,16 @@ final class TreemapNSView: NSView, CALayerDelegate {
         } else {
             tileLayer.frame = bounds
         }
-        relayout()
+        // Squarify is not monotone under resize: recomputing it every frame reorganises the
+        // tiles wholesale (the flicker). During a live drag, keep the layout FROZEN and just
+        // affine-scale the existing tiles into the new bounds — spatially stable, tiles only
+        // stretch (a pure ortho-camera rescale). A full squarified relayout re-settles when
+        // the drag ends (viewDidEndLiveResize).
+        if renderer != nil, inLiveResize, !tiles.isEmpty, layoutRect.width > 0, layoutRect.height > 0 {
+            packInstances(denom: colorDenom, from: layoutRect, to: bounds.insetBy(dx: 1, dy: 1))
+        } else {
+            relayout()
+        }
         presentTiles()
         overlayLayer.setNeedsDisplay()
     }
@@ -352,10 +369,11 @@ final class TreemapNSView: NSView, CALayerDelegate {
         hovered = nil
         guard let controller, let zoomRoot, bounds.width > 1, bounds.height > 1 else {
             tiles = []; colors.removeAll(keepingCapacity: true); instances.removeAll(keepingCapacity: true)
-            regions = [:]; regionsBuilt = false
+            regions = [:]; regionsBuilt = false; layoutRect = .zero
             return
         }
         let rect = bounds.insetBy(dx: 1, dy: 1)
+        layoutRect = rect
         let rootFiles = rootFileTiles(for: zoomRoot, controller: controller)
         let needRegions = selection != nil
         let result = controller.treemapLayout(root: zoomRoot, rect: rect, rootFiles: rootFiles,
@@ -386,8 +404,9 @@ final class TreemapNSView: NSView, CALayerDelegate {
             if s > maxSize { maxSize = s }
         }
         let denom = Double(maxSize)
+        colorDenom = denom
         if renderer != nil {
-            packInstances(denom: denom)
+            packInstances(denom: denom, from: layoutRect, to: layoutRect)
         } else {
             colors.removeAll(keepingCapacity: true)
             colors.reserveCapacity(n)
@@ -401,16 +420,33 @@ final class TreemapNSView: NSView, CALayerDelegate {
     /// Pack `tiles` into GPU `instances` (Metal path): world rect on the ground plane
     /// (top-left, height 0), packed sRGB colour, dim folded in. Sub-pixel tiles are
     /// culled here — `instances` may be shorter than `tiles`; hit-testing uses `tiles`.
-    private func packInstances(denom: Double) {
+    ///
+    /// The tile rects were squarified in `src`; they are affine-mapped into `dst`. For a
+    /// full layout `src == dst` (identity). During a live resize the squarified layout is
+    /// frozen (`src` = the layout rect) and stretched into the new bounds (`dst`) instead
+    /// of re-running the non-monotone squarify every frame — a pure ortho-camera rescale.
+    private func packInstances(denom: Double, from src: CGRect, to dst: CGRect) {
         let n = tiles.count
         instances.removeAll(keepingCapacity: true)
         instances.reserveCapacity(n)
+        let sx = src.width > 0 ? Double(dst.width) / Double(src.width) : 1
+        let sy = src.height > 0 ? Double(dst.height) / Double(src.height) : 1
+        let identity = sx == 1 && sy == 1 && src.origin == dst.origin
         let highlightName = selectedExt?.displayName
         let hasSearch = highlightName == nil && !searchMatchIDs.isEmpty
         for i in 0..<n {
             let tile = tiles[i]
-            let r = tile.rect
-            if r.width <= 0.5 || r.height <= 0.5 { continue }
+            let r0 = tile.rect
+            let x: Double, y: Double, w: Double, h: Double
+            if identity {
+                x = Double(r0.minX); y = Double(r0.minY); w = Double(r0.width); h = Double(r0.height)
+            } else {
+                x = Double(dst.minX) + (Double(r0.minX) - Double(src.minX)) * sx
+                y = Double(dst.minY) + (Double(r0.minY) - Double(src.minY)) * sy
+                w = Double(r0.width) * sx
+                h = Double(r0.height) * sy
+            }
+            if w <= 0.5 || h <= 0.5 { continue }
             let weight = min(1.0, max(0.0, pow(Double(sizeScratch[i]) / denom, 0.40)))
             var dim: Float = 0
             if let highlightName {
@@ -420,8 +456,8 @@ final class TreemapNSView: NSView, CALayerDelegate {
                 dim = 1
             }
             instances.append(TileInstance(
-                origin: SIMD4<Float>(Float(r.minX), 0, Float(r.minY), 0),
-                size: SIMD4<Float>(Float(r.width), 0, Float(r.height), dim),
+                origin: SIMD4<Float>(Float(x), 0, Float(y), 0),
+                size: SIMD4<Float>(Float(w), 0, Float(h), dim),
                 color: floatColor(for: tile, weight: weight)))
         }
     }

--- a/specs/README.md
+++ b/specs/README.md
@@ -22,5 +22,6 @@ Principe directeur (repris du plan) : **intégrité > performance > robustesse >
 | [SPEC-06](SPEC-06-pluggable-backends.md) | Backends pluggables | S6 | ~1 j/backend | — |
 | [SPEC-07](SPEC-07-distribution.md) | Distribution **DMG signé/notarisé via GitHub** (v1) | J1.1–J1.5, D4 | 1–2 j | — |
 | [SPEC-08](SPEC-08-accessibility.md) | Accessibilité & i18n complètes | J10.1–J10.4, J9.5 | 1–2 j | SPEC-01 (partiel) |
+| [SPEC-09](SPEC-09-gpu-treemap-rendering.md) | Rendu GPU **3D-natif** du treemap (Metal, projection 2D ortho) | perf-resize (PR #17) | 2–3 j | PR #17 (couture NSView, faite) |
 
 **Ordre recommandé** : SPEC-02 (débloque SPEC-04 et ferme A6/A7 proprement) → SPEC-01 → SPEC-03 → SPEC-08 → SPEC-04 → SPEC-05/06/07 selon priorités produit.

--- a/specs/SPEC-09-gpu-treemap-rendering.md
+++ b/specs/SPEC-09-gpu-treemap-rendering.md
@@ -1,0 +1,140 @@
+# SPEC-09 — Rendu GPU **3D-natif** du treemap (Metal, projection 2D orthographique)
+
+> **Findings** : chantier **perf-resize** (continuation de la PR #17 « solution C »). Profilage : après avoir supprimé la taxe SwiftUI (`NSHostingView.layout` 5373→101, `dispatchActions` 3395→1), le coût a basculé sur la **rastérisation CPU** des tuiles — `CGContextFillRect` ≈ 7482 échantillons pendant un drag, sur le `NSEventThread`. Sur un arbre pathologique (`.build/ModuleCache`, des milliers de tuiles minuscules) le remplissage par tuile reste le plancher.
+> **Décision d'architecture (actée)** : le moteur de rendu est **3D-natif dès le départ** — vraie géométrie 3D, caméra, matrices MVP, depth buffer. L'affichage courant est sa **projection orthographique top-down** : tuiles plates (hauteur = 0) vues d'aplomb → **iso-visuel strict** avec la visu 2D actuelle. Une projection ortho de tuiles plates **préserve exactement les proportions** (pas de fuyantes), donc le 2D d'aujourd'hui est mathématiquement identique. **Passer en 3D** (plus tard, §9) = changer la **caméra** (perspective + orbite) et donner une **hauteur** aux tuiles — **aucune réécriture**, le pipeline est déjà 3D.
+> **Contrainte produit** : **on garde les tuiles 2D actuelles.** Le 3D reste **différé (+3–6 mois)** côté produit.
+> **Statut** : 📋 **PROPOSÉ** — à planifier. La couture (NSView séparant layout/interaction de `draw()`) est déjà en place (PR #17), ce qui rend le renderer Metal un **remplacement local** du seul dessin des tuiles.
+
+## 1. Objectif
+
+Rendre le treemap sur le **GPU** au lieu du CPU, via un **pipeline 3D natif** dont le rendu courant est une **projection orthographique 2D**, pour que le resize (et à terme le zoom, puis la 3D) soit fluide même sur des dizaines de milliers de tuiles — **sans toucher au visuel ni à l'interaction aujourd'hui**. Le raisonnement, prouvé sur ce projet :
+
+- L'ancien `Canvas` + `.drawingGroup()` était fluide **parce qu'il passait par le GPU** (Metal offscreen) ; son coût réel était la **taxe de reconcile SwiftUI** autour, pas le dessin.
+- La solution C (PR #17) a supprimé cette taxe (AppKit pilote le resize) mais a **rapatrié le dessin sur le CPU** (`CALayer.draw` → Core Graphics).
+- **Metal = les deux gains à la fois** : dessin GPU **et** pas de taxe SwiftUI.
+
+Un treemap est un ensemble de quads colorés axis-aligned : le cas d'école du **GPU instancing** (un seul draw call pour N tuiles). Le remplissage séquentiel de milliers de rects sur un thread devient un upload de N instances + **un** appel de dessin, rastérisé en parallèle.
+
+## 2. État actuel du code (vérifié)
+
+Couture (posée par la PR #17) — le dessin est **déjà isolé** du reste :
+
+- [TreemapView.swift:13](../Sources/SpaceMatters/Views/TreemapView.swift#L13) `struct TreemapView` (wrapper SwiftUI : observation + overlay hover + a11y) → [:70](../Sources/SpaceMatters/Views/TreemapView.swift#L70) `TreemapRepresentable: NSViewRepresentable` → [:110](../Sources/SpaceMatters/Views/TreemapView.swift#L110) `final class TreemapNSView: NSView, CALayerDelegate`.
+- Deux `CALayer` : [:133](../Sources/SpaceMatters/Views/TreemapView.swift#L133) `tileLayer` (tuiles, redessiné au relayout) + [:134](../Sources/SpaceMatters/Views/TreemapView.swift#L134) `overlayLayer` (hover + sélection, redessiné seul).
+- **Le goulot** : [`drawTiles`](../Sources/SpaceMatters/Views/TreemapView.swift#L387) — boucle par tuile avec [`ctx.setFillColor` + `ctx.fill(r)`](../Sources/SpaceMatters/Views/TreemapView.swift#L398-L399), [`drawLinearGradient` par tuile](../Sources/SpaceMatters/Views/TreemapView.swift#L405) (cushion), remplissage de dim, `stroke` de bordure. **Tout sur CPU.**
+- Contournement actuel du coût pixel : [`viewWillStartLiveResize` passe `contentsScale` à 1](../Sources/SpaceMatters/Views/TreemapView.swift#L208) (¼ des pixels pendant le drag, re-net à la fin). Pansement — Metal le rend inutile (§4.7).
+- Orientation : rects top-left, contexte CG bottom-left → [`flip(_:_:)` par tuile](../Sources/SpaceMatters/Views/TreemapView.swift#L383). Bug historique (survol inversé verticalement) corrigé côté hit-test [:490](../Sources/SpaceMatters/Views/TreemapView.swift#L490).
+
+Ce qui **ne bouge pas** (et donc n'est pas réécrit) :
+
+- **Layout** : [`TreemapLayout.compute`](../Sources/SpaceMatters/Views/TreemapLayout.swift#L77) + [`Cache`](../Sources/SpaceMatters/Views/TreemapLayout.swift#L49) size-independent + [`squarifySorted`](../Sources/SpaceMatters/Views/TreemapLayout.swift#L192) ; seule la **placement** re-tourne par frame, la structure triée est mémoïsée. Reste CPU (bon marché après cache). Piloté par [`ScanController.treemapLayout`](../Sources/SpaceMatters/ViewModel/ScanController.swift#L453), invalidé par [`version`](../Sources/SpaceMatters/ViewModel/ScanController.swift#L30).
+- **Couleurs** : [`computeColors`](../Sources/SpaceMatters/Views/TreemapView.swift#L302) + LUT `(hueIndex, bucket luminance)` → aujourd'hui `CGColor` ([`cgColor(for:weight:)`](../Sources/SpaceMatters/Views/TreemapView.swift#L326)), via [`Theme.treemapTypeColor(hueIndex:weight:)`](../Sources/SpaceMatters/App/Theme.swift#L61). **Seul changement** : sortir des **RGBA packés** (`SIMD4<Float>`) au lieu de `CGColor`.
+- **Interaction** : [`tileAt`](../Sources/SpaceMatters/Views/TreemapView.swift#L490), hover ([:507](../Sources/SpaceMatters/Views/TreemapView.swift#L507)), `mouseUp` ([:524](../Sources/SpaceMatters/Views/TreemapView.swift#L524)), `menu(for:)` ([:568](../Sources/SpaceMatters/Views/TreemapView.swift#L568)) — **inchangés** (hit-test CPU sur `tiles`).
+- **Overlay** actuel : [`drawOverlay`](../Sources/SpaceMatters/Views/TreemapView.swift#L432) (1 spotlight + 1 liseré + 1 outline) en CoreGraphics — **migre en 2ᵉ passe Metal** (§4.5) ; le code CG reste comme fallback.
+
+Aucun usage Metal aujourd'hui (grep : seul un `.drawingGroup()` résiduel dans `KubernetesResultView`, hors sujet).
+
+## 3. Conception retenue
+
+Le renderer est un **pipeline Metal à quads instancés, 3D-natif, projeté en ortho 2D**. Les décisions, chacune actée :
+
+1. **GPU instancing** — un quad unité (généré depuis `[[vertex_id]]`, sans VBO) dessiné **N fois** via `drawPrimitives(instanceCount: N)` ; chaque instance lit son `{origin, size, color}` dans un **buffer d'instances** indexé par `[[instance_id]]`. Un seul draw call pour toutes les tuiles. *(Modèle OpenGL équivalent : `glDrawArraysInstanced` + attribut par-instance ; MSL au lieu de GLSL, pipeline state pré-compilé au lieu de l'état global mutable.)*
+
+2. **3D-natif, projection ortho** — vertices 3D, **matrice MVP** pilotée par une caméra, depth buffer actif. Aujourd'hui : `height = 0`, caméra orthographique top-down → sortie pixel-identique au 2D. Ce choix a **le même coût par frame** qu'un pipeline 2D figé, mais rend la 3D (§9) gratuite (caméra + hauteur) au lieu d'une réécriture. La matrice MVP remplace le `flip(_:_:)` par-tuile (flip encodé une fois dans la caméra).
+
+3. **Rendu à la demande** — `CAMetalLayer` piloté manuellement (draw appelé depuis `setFrameSize`/`apply`), GPU au repos quand rien ne change. Pas de `MTKView` (évite un sous-view + delegate ; on garde notre `NSView` unique et son interaction).
+
+4. **Buffer shared + anneau** — `MTLStorageModeShared` (mémoire unifiée Apple Silicon : CPU écrit, GPU lit, **zéro copie/blit**). Anneau de 2–3 buffers + `DispatchSemaphore` pour que le CPU n'écrase pas un buffer encore lu par le GPU (utile pendant la rafale de frames d'un live-resize).
+
+5. **Bordures par gouttière inset** — effacer la couche en `treemapBorder`, puis dessiner chaque fill **inséré de 0,6 px** → la couleur de bord transparaît comme des gouttières. Zéro géométrie de bordure, look « grille » net (le trick classique des treemaps).
+
+6. **Overlay = 2ᵉ passe Metal** — sélection + hover rendus par une poignée d'instances, bordure/dim en **fragment shader** (SDF). C'est *le* lieu des futurs effets de highlight (§4.8) ; le mettre en Metal dès maintenant évite d'écrire un overlay CPU qu'on arracherait ensuite. **Phase 1 : reproduit le look actuel à l'identique.**
+
+## 4. Plan d'implémentation
+
+Principe : **remplacer uniquement les tripes du dessin**. Layout, couleurs (source), hit-test et interaction restent tels quels.
+
+### 4.1 Nouveau fichier `Views/TreemapMetalRenderer.swift`
+Encapsule tout le Metal, testable/remplaçable, sans polluer `TreemapNSView` :
+- `device: MTLDevice`, `commandQueue`, `pipelineState: MTLRenderPipelineState`, `depthState: MTLDepthStencilState`, anneau de `instanceBuffers: [MTLBuffer]`, `inflightSemaphore`, une `Camera` (§4.2).
+- Struct d'instance **3D-native** (compacte, alignée) :
+  ```
+  struct TileInstance {          // 48 o : 3× SIMD4<Float>
+      var origin: SIMD4<Float>   // x, y, z(=0) en espace monde ; w = padding
+      var size:   SIMD4<Float>   // largeur, profondeur, hauteur(=0 aujourd'hui), w = padding
+      var color:  SIMD4<Float>   // RGBA linéaire ; le dim est déjà folded dedans
+  }
+  ```
+  Aujourd'hui `origin.z = 0` et `size.height = 0` → chaque instance est un **quad plat** posé sur le plan sol ; demain `size.height = f(size|count|depth)` → une **boîte** extrudée, **même struct**.
+- `func render(instances:, drawable:, camera: Camera, borderColor:)`.
+
+### 4.2 Caméra & convention monde (le cœur du 3D-natif)
+- **Monde** : plan **sol XZ** (comme une carte / une ville), axe **Y = hauteur** (« code city » : les tuiles gisent au sol, les boîtes montent en Y). Le layout squarify (rects top-left en pixels) est mappé sur le plan sol par une transformation fixe (échelle + flip top-left → monde).
+- **Caméra** = `view` (position/orientation) × `projection`, encapsulée dans `Camera { viewProjection() -> float4x4 }`. **Aujourd'hui** : caméra **orthographique**, au-dessus, regardant droit vers le bas (−Y), *up* aligné pour reproduire la disposition des rects → ortho top-down = les rects 2D au pixel près (garantie iso-visuel).
+- **Depth buffer** activé dès maintenant (`MTLDepthStencilState`, `.depth32Float`) : inerte tant que les tuiles sont plates, **prêt** pour le recouvrement des boîtes en 3D. Coût négligeable.
+
+### 4.3 Shaders `Views/Treemap.metal`
+- **Vertex** : sommet de quad (`vertex_id` → 2 triangles ; demain 12 triangles de boîte) placé par `instance.origin/size`, transformé en clip space par la **MVP caméra** (uniforme). Passe `uv∈[0,1]` et la taille pixel au fragment.
+- **Fragment** : `fill = instance.color` ; **cushion** = reproduction des 3 stops actuels ([TreemapView.swift:160-165](../Sources/SpaceMatters/Views/TreemapView.swift#L160-L165)) — blanc α .16 en haut → 0 à 0.45 → noir α .20 en bas, composité sur le fill, **skippé** si tuile < 6 px (comme aujourd'hui) ; **bordure** par gouttière inset (fond pré-effacé en `treemapBorder`, fill inséré de 0,6 px). Sortie sRGB (§6).
+
+### 4.4 Buffer d'instances — discipline d'alloc
+- Réutiliser un `MTLBuffer` par slot d'anneau, **agrandi seulement** quand `tiles.count` dépasse la capacité (comme `sizeScratch`). Jamais d'alloc par frame.
+- Remplissage : boucle unique sur `tiles`, culling sub-pixel **côté CPU avant écriture** (on n'envoie pas une tuile ≤ 0,5 px — déjà filtré [:395](../Sources/SpaceMatters/Views/TreemapView.swift#L395)). Écriture directe dans le buffer shared.
+- Couleurs : `computeColors` produit des `SIMD4<Float>` (mêmes valeurs que `treemapTypeColor`, converties une fois) au lieu de `CGColor`. Le **dim** (highlight/search) est **folded** dans la couleur au remplissage → un simple recalcul du buffer sur changement de highlight (peu fréquent), pas de seconde passe.
+
+### 4.5 Intégration dans `TreemapNSView`
+- Remplacer `tileLayer` (CALayer CPU) par une `CAMetalLayer` (`tileMetalLayer`), `device` assigné, `pixelFormat` calibré (§6), `framebufferOnly = true`, `presentsWithTransaction = true` (§6 gotcha resize).
+- `relayout()`/`apply()` inchangés dans leur logique ; à la fin, au lieu de `tileLayer.setNeedsDisplay()` → `renderer.render(...)` synchrone.
+- `setFrameSize` : mettre à jour `tileMetalLayer.drawableSize = bounds.size * scale`, puis render. **Supprimer** le hack `contentsScale = 1` du live-resize (§4.7).
+- **Overlay** (sélection + hover) : 2ᵉ passe Metal dans le même drawable (spotlight `evenOdd` → test dedans/dehors + liseré SDF ; outline hover → SDF). **Phase 1 : look actuel à l'identique.** Le `drawOverlay` CG reste comme fallback (§4.6).
+
+### 4.6 Repli (défensif)
+Si `MTLCreateSystemDefaultDevice()` renvoie `nil` (jamais sur macOS 15, mais by-the-book) → conserver le chemin CoreGraphics actuel (`drawTiles`/`drawOverlay`) en fallback. Le code de dessin CG **n'est pas supprimé**, il devient le plan B → **pas de régression possible**.
+
+### 4.7 Bonus attendu : retrait du pansement live-resize
+Metal rastérise le plein retina quasi gratuitement → plus besoin du `contentsScale = 1` pendant le drag ([:208-217](../Sources/SpaceMatters/Views/TreemapView.swift#L208-L217)). Le treemap reste **net pendant** le resize, pas seulement à la fin.
+
+### 4.8 Headroom effets — débloqué par §4.5, **hors périmètre** (Phase 2)
+Une fois bordures/sélection/hover en fragment shader, ces effets deviennent des changements d'un uniforme, impayables sur CPU par frame — **à ne PAS allumer en Phase 1** (romprait l'iso-visuel). Consignés comme cap produit, à cadrer dans un chantier dédié : glow de sélection animé (falloff de distance + `time`), bordures SDF anti-aliasées, dim animé (fondu 150 ms), matches de recherche qui « respirent ». *(Les effets animés impliquent un rendu 60 fps borné par `CADisplayLink` le temps de la transition — pas une boucle continue.)*
+
+## 5. Vérification
+
+- **Iso-visuel (méthode captures établie)** : capture côté-à-côté **avant (CG) / après (Metal)** sur le même scan — couleurs, sheen cushion, gouttières, dim (highlight extension + search), spotlight de sélection, outline de hover. Doivent être indiscernables (tolérance sRGB, §6).
+- **Orientation** : re-vérifier le bug historique — survoler les tuiles **du haut** highlight bien celles du haut (le flip est maintenant dans la projection).
+- **Perf (objectif du chantier)** : `sample`/Instruments (Metal System Trace) sur `.build/ModuleCache` pendant un drag continu → la rastérisation CPU (`CGContextFillRect`) **disparaît** du profil ; temps de frame GPU < 1 ms ; `NSEventThread` déchargé.
+- **Interaction** : clic (reveal), double-clic (zoom/open/zoomOut), menu contextuel, sélection depuis la liste → **inchangés** (hit-test CPU non touché).
+- **Tests** : la logique testée (`TreemapLayout`, `squarify*`) est inchangée → tests existants verts. Ajouter un test unitaire sur le **packing d'instances** (N tuiles → N `TileInstance` attendus, culling sub-pixel appliqué) — pur, sans GPU.
+
+## 6. Risques & hypothèses (🔬)
+
+- 🔬 **Espace colorimétrique** : CG dessine en sRGB device RGB ; le drawable Metal doit matcher (`.bgra8Unorm_srgb` vs conversion gamma dans le shader). Mal calibré → tuiles plus claires/sombres. À figer en capture avant de généraliser.
+- 🔬 **`CAMetalLayer` + live-resize** : sans `presentsWithTransaction = true` + présentation **synchrone** (`commit` → `waitUntilScheduled` → `drawable.present()` dans la même transaction que le changement de bounds), la couche Metal **retarde/tearing** derrière la fenêtre pendant le drag. C'est LE gotcha ; à traiter dès le départ.
+- 🔬 **Bordure inset** : gouttière opaque `treemapBorder` vs stroke semi-transparent 0,6 px de l'actuel. Valider en capture ; repli possible sur une bordure SDF (fragment shader) si l'écart déplaît.
+- **Placement CPU comme nouveau plancher** : une fois la raster GPU gratuite, le coût résiduel par frame devient `squarifySorted` (O(n) arith + alloc des rects). Si mesuré gênant : réutiliser les buffers de rects, voire paralléliser — **hors périmètre**, à mesurer après coup.
+- **Intel Macs** (macOS 15, minoritaires) : `storageModeShared` OK mais moins optimal ; pas bloquant.
+
+## 7. Effort & dépendances
+
+**2–3 jours.** Indépendant. La couture NSView de la PR #17 est le prérequis — **déjà en place**. Aucune dépendance externe (Metal est système). Le code CG actuel reste comme fallback, donc pas de régression possible en cas de souci device.
+
+## 8. Périmètre — ce que cette SPEC fait / ne fait PAS
+
+**Fait** : un renderer **3D-natif** (géométrie 3D, caméra, MVP, depth) rendu en **projection orthographique 2D**, iso-visuel avec les tuiles actuelles, sur GPU. Tuiles **et** overlay (sélection/hover) en Metal.
+**Ne fait PAS** (aujourd'hui) :
+- Aucun changement visible : visu, palette, layout, interaction **inchangés**. **Iso-visuel strict.**
+- Pas de texte dans les tuiles (resté retiré).
+- **Pas d'effets animés** : l'overlay Metal reproduit le look actuel à l'identique ; le headroom shader (§4.8) est débloqué mais **éteint** — c'est Phase 2.
+- Pas de hauteur ≠ 0, pas de caméra perspective, pas d'orbite : la **3D reste débranchée** (caméra ortho top-down, `size.height = 0`). Voir §9.
+
+## 9. Activation 3D — différée côté **produit** (+3–6 mois), déjà **architecturée**
+
+Le 3D n'est **pas** un futur chantier de refonte, c'est un **basculement de configuration** d'un moteur déjà 3D. Rien à réécrire — on « rebranche » ce que §4.2 a posé :
+
+- **Caméra** : `projection` ortho → **perspective** ; `view` top-down → **inclinée + orbitable**. Pipeline, shaders, buffer d'instances : identiques.
+- **Hauteur** : `size.height` passe de 0 à `f(donnée)` → les quads plats deviennent des **boîtes** (le vertex shader passe de 2 à 12 triangles ; même struct d'instance).
+- **Depth buffer** : déjà actif (§4.2) → recouvrement des boîtes correct sans rien changer.
+- **Cushion → shading** : le sheen top→bottom devient un vrai éclairage par normale de face — même emplacement dans le fragment shader.
+
+Dimensions candidates pour la hauteur : `size(metric)`, `fileCount` ([FSNode.swift:28](../Sources/SpaceMatters/Model/FSNode.swift#L28)), profondeur d'arbre. ⚠️ **`FSNode` n'a aucun champ temporel** (vérifié : identique à `main`) — une hauteur « âge/fraîcheur » impliquerait d'ajouter `mtime` au scan (dépendance à cadrer séparément, hors de cette SPEC).
+
+→ Décision produit : **tuiles 2D maintenant**, activation 3D dans 3–6 mois. Cette SPEC garantit que cette activation sera un **réglage de caméra + un attribut de hauteur**, pas une réécriture.


### PR DESCRIPTION
## What

Moves the treemap **tile rendering to the GPU** (Metal, instanced quads) and makes the **squarify layout monotone under resize**. Result: a window resize is now buttery. No mini-freezes, no black bands, no seam shimmer, and no wholesale tile reorganisation.

Planned in **[specs/SPEC-09](specs/SPEC-09-gpu-treemap-rendering.md)**.

> **Stacked on #17** (base = `perf/treemap-resize-allocations`). This builds directly on solution C's NSView seam and shows only the GPU plus layout work. Merge #17 first (or GitHub will retarget the base to `main` when it merges).

## Why

#17 removed the SwiftUI tax (`NSHostingView.layout` 5373→101) but profiling showed the cost then moved to **CPU rasterisation** of the tiles: `CGContextFillRect` ≈ 7482 samples on the `NSEventThread` during a live drag, heavy on a pathological tree (`.build/ModuleCache`, thousands of tiny tiles). And separately, squarify is **not monotone** under resize, so recomputing it per frame reorganised the whole tiling (visible flicker). This PR fixes both.

## How

**3D-native Metal renderer, projected orthographically (iso-visual 2D today).** Each tile is one instance `{origin, size, color}`, and a single `drawPrimitives(instanceCount:)` draws them all. The engine is 3D from day one (3D geometry, MVP camera, depth buffer). Today's map is its ortho top-down projection of flat tiles, so it is pixel-identical to the old CG map, and going 3D later is a camera plus height change, not a rewrite (SPEC-09 §9).

- **Backing-layer resize**: the `CAMetalLayer` is the view's backing layer (`makeBackingLayer`, like `MTKView`), resized in lockstep with the view → no black bands.
- **4× MSAA**: smooths the fractional tile seams so they do not shimmer as edges crawl across the pixel grid during a drag (memoryless on Apple Silicon, resolved in-tile, near-free).
- **Monotone layout**: `TreemapLayout` split into `decideRows()` (the discrete squarify choices: row grouping, orientation, which children recurse, frozen per node in the cache) and `placeRows()` (continuous geometry for a fixed decomposition at any rect). A resize reruns only `placeRows`, so the layout is a continuous function of size: no reorganisation during the drag, no settle jump on release. At the reference rect the output equals plain squarify, so the at-rest look is unchanged.
- **Allocation discipline**: triple-buffered shared instance buffer plus semaphore (zero per-frame alloc), colours packed to sRGB `SIMD4` in the same LUT shape as the CG path, dim folded per-instance. The live-resize `contentsScale` down-scaling hack was dropped (Metal renders full-res cheaply).
- **Crash-safe**: with no GPU (`init?` returns nil) it falls back to the intact CoreGraphics `drawTiles`/`drawOverlay` path, so there is no way to regress into a broken state.

## Scope (M1) and follow-ups

- The selection/hover **overlay stays CoreGraphics** this milestone. Moving it to a Metal pass (SPEC §4.5) is deferred.
- **Animated shader effects** (pulsing selection glow, SDF borders, animated dim, SPEC §4.8) are unlocked by the shader path but **off** (iso-visual).
- **Real 3D** (perspective camera plus extruded boxes, SPEC §9) is deferred to a product decision (plus 3 to 6 months). The architecture already supports it.
- Monotone-layout tradeoff (assumed): after a large resize the frozen structure is not re-optimised for the new aspect until the next data or zoom change, so tiles can drift from perfectly square. That is the price of zero reorganisation.

## Verification

- **33 tests green**: the layout refactor preserves the tested squarify/compute output (at-rest look unchanged).
- **Live-verified** on the pathological `.build/ModuleCache` scan: fluid resize confirmed by the user across vertical, horizontal and diagonal drags. Black bands, seam shimmer and reorganisation all gone.

## Commits

- `docs(spec)` SPEC-09, GPU 3D-native treemap rendering
- `feat` GPU-render tiles with Metal instanced quads (M1)
- `fix` CAMetalLayer as the backing layer (kills resize black bands)
- `perf` 4× MSAA to stop tile-seam shimmer
- `perf` freeze the squarified layout during resize *(stopgap, superseded)*
- `perf` monotone layout, split squarify into decide and place *(the real fix)*
