### PR TITLE
Release drafter: collapse manually added labels too

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,7 +11,10 @@ on:
   push:
     branches: [main]
   pull_request:
-    types: [opened, reopened, synchronize, edited]
+    # `labeled` matters: a manually-added category label must also trigger the
+    # single-category collapse below, or a hand-labelled PR (e.g. enhancement +
+    # performance) shows up in two changelog sections.
+    types: [opened, reopened, synchronize, edited, labeled]
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
## Problem

The v0.3.0 draft listed **#18 in both Features and Performance**. Root cause: #18 was hand-labelled `enhancement` plus `performance` (the title matches no autolabeler regex). The single-category priority collapse *was* in place (#16), but the `pull_request` trigger only listened to `opened/reopened/synchronize/edited`, **not `labeled`**, so a manual label add never ran the collapse.

Timeline for #18:
- `22:05` the bot autolabels `documentation` (touches `.md`)
- `22:08` a human removes `documentation` and adds `enhancement` **and** `performance` → no workflow event fires → the collapse never runs

## Fix

Add `labeled` to the `pull_request` trigger types so a manually added category label also runs the collapse.

**Loop-safe:** labels applied by the workflow's own jobs (autolabeler, collapse) use `GITHUB_TOKEN`, and GitHub does not re-trigger workflows on `GITHUB_TOKEN`-authored events. Only human label additions re-run the collapse.

## Already cleaned up (out of band)

- Removed `performance` from #18 (kept `enhancement`).
- Re-ran the drafter → the v0.3.0 draft no longer has the duplicate.
