### PR TITLE
Audit remediation: tree-lifecycle integrity, process-tree kills and safety fences (1 critical, 12 major, 17 minor)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ SpaceMatters.app/
 
 # Release artifacts
 *.dmg
+docs/audit/

--- a/Sources/SpaceMatters/App/HeadlessScan.swift
+++ b/Sources/SpaceMatters/App/HeadlessScan.swift
@@ -80,16 +80,21 @@ enum HeadlessScan {
 
     /// Headless VM scan that prints rising counts as the stream arrives — proves
     /// the find-over-SSH backend updates progressively, not in one blocking call.
-    static func runVM(runtime: String, scope: String) {
+    /// Returns an exit code (0 ok, 1 failure) so scripts can rely on it.
+    @discardableResult
+    static func runVM(runtime: String, scope: String) -> Int32 {
         let machines = VMProbe.detect()
         print("detected VMs:")
         for m in machines {
             print("  \(m.runtime.rawValue) \(m.name) — \(m.running ? "running" : "stopped"), disk \(Format.bytes(m.diskBytes))")
         }
         guard let machine = machines.first(where: { $0.runtime.rawValue.lowercased() == runtime.lowercased() }) else {
-            print("no \(runtime) machine found"); return
+            FileHandle.standardError.write(Data("error: no \(runtime) machine found\n".utf8)); return 1
         }
-        guard machine.running else { print("\(machine.runtime.rawValue) is not running — cannot scan"); return }
+        guard machine.running else {
+            FileHandle.standardError.write(Data("error: \(machine.runtime.rawValue) is not running — cannot scan\n".utf8))
+            return 1
+        }
 
         let vmScope: VMScope = (scope.lowercased() == "containers") ? .containers : .full
         let cmd = VMProbe.scanCommand(machine: machine, scope: vmScope)
@@ -122,10 +127,18 @@ enum HeadlessScan {
         for row in scanner.snapshotExtensions(metric: .physical, limit: 6) {
             print("  \(row.name): \(Format.bytes(row.physical)) (\(Format.count(row.count)) files)")
         }
+        if let failure = scanner.failure {
+            FileHandle.standardError.write(Data("error: \(failure)\n".utf8))
+            return 1
+        }
+        return 0
     }
 
-    static func runContainers() {
-        guard let engine = ContainerProbe.detect().first else { print("no reachable container engine"); return }
+    @discardableResult
+    static func runContainers() -> Int32 {
+        guard let engine = ContainerProbe.detect().first else {
+            FileHandle.standardError.write(Data("error: no reachable container engine\n".utf8)); return 1
+        }
         print("engine: \(engine.displayName) (\(engine.executable))")
         let snap = ContainerQueries.fetchAll(engine)
         print("df:")
@@ -143,13 +156,15 @@ enum HeadlessScan {
             }
         }
         print("containers: \(snap.containers.count), volumes: \(snap.volumes.count)")
+        return 0
     }
 
-    static func runK8s(context: String?) {
+    @discardableResult
+    static func runK8s(context: String?) -> Int32 {
         let contexts = K8sProbe.contexts()
         print("contexts: \(contexts.map { $0.isCurrent ? "\($0.name)*" : $0.name }.joined(separator: ", "))")
         guard let ctx = context ?? contexts.first(where: \.isCurrent)?.name ?? contexts.first?.name else {
-            print("no kube context"); return
+            FileHandle.standardError.write(Data("error: no kube context\n".utf8)); return 1
         }
         print("analyzing context: \(ctx)")
         var pvcs = K8sQueries.pvcs(context: ctx)
@@ -170,6 +185,7 @@ enum HeadlessScan {
         }
         let reclaimable = pvs.filter(\.reclaimable)
         print("PVs: \(pvs.count)  reclaimable=\(reclaimable.count) (\(Format.bytes(reclaimable.reduce(0) { $0 + $1.capacity })))")
+        return 0
     }
 
     static func listVolumes() {

--- a/Sources/SpaceMatters/App/SpaceMattersApp.swift
+++ b/Sources/SpaceMatters/App/SpaceMattersApp.swift
@@ -6,28 +6,32 @@ import AppKit
 @main
 enum Entry {
     static func main() {
+        // Headless subcommands exit with a real status code (0 ok, 1 failure,
+        // 2 usage) so scripts can tell a broken run from a clean one — and a
+        // subcommand missing its argument prints usage instead of silently
+        // falling through to the GUI.
         let args = CommandLine.arguments
         if args.contains("--volumes") {
             HeadlessScan.listVolumes()
-            return
+            exit(0)
         }
         if args.contains("--containers") {
-            HeadlessScan.runContainers()
-            return
+            exit(HeadlessScan.runContainers())
         }
         if let idx = args.firstIndex(of: "--k8s") {
             let ctx = idx + 1 < args.count ? args[idx + 1] : nil
-            HeadlessScan.runK8s(context: ctx)
-            return
+            exit(HeadlessScan.runK8s(context: ctx))
         }
-        if let idx = args.firstIndex(of: "--vm-scan"), idx + 1 < args.count {
-            let runtime = args[idx + 1]
+        if let idx = args.firstIndex(of: "--vm-scan") {
+            guard idx + 1 < args.count else {
+                print("usage: SpaceMatters --vm-scan <podman|colima> [full|containers]")
+                exit(2)
+            }
             let scope = idx + 2 < args.count ? args[idx + 2] : "full"
-            HeadlessScan.runVM(runtime: runtime, scope: scope)
-            return
+            exit(HeadlessScan.runVM(runtime: args[idx + 1], scope: scope))
         }
-        if let idx = args.firstIndex(of: "--scan"), idx + 1 < args.count {
-            exit(HeadlessScan.run(paths: Array(args[(idx + 1)...])))
+        if let idx = args.firstIndex(of: "--scan") {
+            exit(HeadlessScan.run(paths: Array(args[(idx + 1)...]))) // empty → usage, exit 2
         }
         SpaceMattersApp.main()
     }

--- a/Sources/SpaceMatters/Model/ExtKey.swift
+++ b/Sources/SpaceMatters/Model/ExtKey.swift
@@ -97,12 +97,15 @@ struct ExtStat {
         count += other.count
     }
 
-    /// Remove a subtree's contribution after it's been deleted (A6).
+    /// Remove a subtree's contribution after it's been deleted (A6). Clamped at
+    /// zero: in exact counting mode the deletion walk counts every hardlink at
+    /// full size while the scan booked later sightings as 0 bytes, so the delta
+    /// can exceed what was ever added — the panel must never show negatives.
     @inline(__always)
     mutating func subtract(_ other: ExtStat) {
-        logical -= other.logical
-        physical -= other.physical
-        count -= other.count
+        logical = max(0, logical - other.logical)
+        physical = max(0, physical - other.physical)
+        count = max(0, count - other.count)
     }
 
     var isEmpty: Bool { logical <= 0 && physical <= 0 && count <= 0 }

--- a/Sources/SpaceMatters/Model/Reconciliation.swift
+++ b/Sources/SpaceMatters/Model/Reconciliation.swift
@@ -50,10 +50,15 @@ struct Reconciliation: Equatable {
 
     private static func trashSize(volumeURL: URL) -> Int64 {
         var total: Int64 = 0
-        let candidates = [
-            FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".Trash"),
-            volumeURL.appendingPathComponent(".Trashes/\(getuid())"),
-        ]
+        // `~/.Trash` lives on the home volume: attribute it to the reconciled
+        // volume only when that's actually where home is — an external disk
+        // would otherwise inherit the internal disk's trash, inflating
+        // `accountedFor` and zeroing out `unaccounted`.
+        var candidates = [volumeURL.appendingPathComponent(".Trashes/\(getuid())")]
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        if sameVolume(home, volumeURL) {
+            candidates.append(home.appendingPathComponent(".Trash"))
+        }
         for dir in candidates {
             guard let e = FileManager.default.enumerator(
                 at: dir,
@@ -66,6 +71,14 @@ struct Reconciliation: Equatable {
             }
         }
         return total
+    }
+
+    private static func sameVolume(_ a: URL, _ b: URL) -> Bool {
+        guard let va = try? a.resourceValues(forKeys: [.volumeIdentifierKey]).volumeIdentifier,
+              let vb = try? b.resourceValues(forKeys: [.volumeIdentifierKey]).volumeIdentifier else {
+            return false
+        }
+        return va.isEqual(vb)
     }
 
     private static func snapshotCount(volumeURL: URL) -> Int {

--- a/Sources/SpaceMatters/Scanner/CleanupEngine.swift
+++ b/Sources/SpaceMatters/Scanner/CleanupEngine.swift
@@ -163,15 +163,18 @@ enum CleanupEngine {
 
     /// Delete the *children* of each of the item's paths. The paths themselves
     /// survive (tools expect their cache directory to exist). Every path must
-    /// live strictly inside `allowedRoot` and be a real directory — a symlinked
-    /// root is refused, so a cache relocated elsewhere is never chased.
+    /// live strictly inside `allowedRoot` **once fully resolved** and be a real
+    /// directory — a symlinked root, a symlinked *intermediate* component
+    /// (`~/.gradle` → an external volume) or a `..` escape are all refused, so
+    /// a cache relocated elsewhere is never chased.
     static func clean(_ item: Cleanable, allowedRoot: String = NSHomeDirectory()) -> CleanResult {
         var result = CleanResult()
         let fm = FileManager.default
         let fence = allowedRoot.hasSuffix("/") ? allowedRoot : allowedRoot + "/"
 
         for root in item.paths {
-            guard root.hasPrefix(fence), root != fence, isRealDirectory(root) else {
+            guard root.hasPrefix(fence), root != fence, isRealDirectory(root),
+                  staysInsideFence(root, allowedRoot: allowedRoot) else {
                 result.refused += 1
                 continue
             }
@@ -198,6 +201,22 @@ enum CleanupEngine {
         var st = stat()
         guard lstat(path, &st) == 0 else { return false }
         return (st.st_mode & S_IFMT) == S_IFDIR
+    }
+
+    /// The textual prefix check can be defeated by a symlinked *intermediate*
+    /// component or a `..`: the path still starts with the fence but its real
+    /// location is elsewhere. The fully-resolved form must stay strictly inside
+    /// the fully-resolved fence for the clean to proceed.
+    private static func staysInsideFence(_ root: String, allowedRoot: String) -> Bool {
+        let fenceReal = resolvedPath(allowedRoot)
+        let fencePrefix = fenceReal.hasSuffix("/") ? fenceReal : fenceReal + "/"
+        let real = resolvedPath(root)
+        return real != fenceReal && real.hasPrefix(fencePrefix)
+    }
+
+    /// Fully-resolved (symlinks + `..`) form of a path.
+    private static func resolvedPath(_ path: String) -> String {
+        URL(fileURLWithPath: path).standardizedFileURL.resolvingSymlinksInPath().path
     }
 
     private static let bufferSize = 256 * 1024

--- a/Sources/SpaceMatters/Scanner/CleanupEngine.swift
+++ b/Sources/SpaceMatters/Scanner/CleanupEngine.swift
@@ -167,6 +167,11 @@ enum CleanupEngine {
     /// directory — a symlinked root, a symlinked *intermediate* component
     /// (`~/.gradle` → an external volume) or a `..` escape are all refused, so
     /// a cache relocated elsewhere is never chased.
+    ///
+    /// Concurrency note: the checks and the removals are separate syscalls
+    /// (TOCTOU). The fence defends against catalog bugs and relocated caches —
+    /// not against code already running as the same user, which could delete
+    /// anything directly and gains nothing from racing this loop.
     static func clean(_ item: Cleanable, allowedRoot: String = NSHomeDirectory()) -> CleanResult {
         var result = CleanResult()
         let fm = FileManager.default

--- a/Sources/SpaceMatters/Scanner/CommandScanner.swift
+++ b/Sources/SpaceMatters/Scanner/CommandScanner.swift
@@ -188,9 +188,19 @@ final class CommandScanner: ScanBackend {
         guard t1 >= 1, t2 > t1, t3 > t2, t3 + 1 < bytes.count else { return }
 
         let type = bytes[0]
-        let blocks = asciiInt(bytes, t1 + 1, t2)
-        let logical = asciiInt(bytes, t2 + 1, t3)
-        let physical = blocks * 512
+        // Reject records whose numbers overflow instead of injecting garbage
+        // sizes into the tree (under -Ounchecked the trap would become a
+        // silent wraparound). The remote stream is not trusted input.
+        guard let blocks = asciiInt(bytes, t1 + 1, t2),
+              let logical = asciiInt(bytes, t2 + 1, t3) else {
+            errAtomic.wrappingAdd(1, ordering: .relaxed)
+            return
+        }
+        let (physical, overflow) = blocks.multipliedReportingOverflow(by: 512)
+        guard !overflow else {
+            errAtomic.wrappingAdd(1, ordering: .relaxed)
+            return
+        }
         let path = String(decoding: bytes[(t3 + 1)...], as: UTF8.self)
 
         if type == 0x64 { // 'd' directory
@@ -246,12 +256,19 @@ final class CommandScanner: ScanBackend {
         accParent = nil; accLogical = 0; accPhysical = 0; accCount = 0
     }
 
-    private func asciiInt(_ b: [UInt8], _ lo: Int, _ hi: Int) -> Int64 {
+    /// `nil` on Int64 overflow (≥ 20 digits) — the caller drops the record.
+    private func asciiInt(_ b: [UInt8], _ lo: Int, _ hi: Int) -> Int64? {
         var value: Int64 = 0
         var i = lo
         while i < hi {
             let c = b[i]
-            if c >= 0x30 && c <= 0x39 { value = value * 10 + Int64(c - 0x30) }
+            if c >= 0x30 && c <= 0x39 {
+                let (m, mo) = value.multipliedReportingOverflow(by: 10)
+                if mo { return nil }
+                let (a, ao) = m.addingReportingOverflow(Int64(c - 0x30))
+                if ao { return nil }
+                value = a
+            }
             i += 1
         }
         return value

--- a/Sources/SpaceMatters/Scanner/CommandScanner.swift
+++ b/Sources/SpaceMatters/Scanner/CommandScanner.swift
@@ -62,7 +62,6 @@ final class CommandScanner: ScanBackend {
         let errPipe = Pipe()
         process.standardOutput = outPipe
         process.standardError = errPipe
-        self.process = process
 
         let thread = Thread { [weak self] in
             self?.readLoop(outPipe.fileHandleForReading, errHandle: errPipe.fileHandleForReading, process: process)
@@ -79,12 +78,22 @@ final class CommandScanner: ScanBackend {
             markFinished()
             return
         }
+        // Published only once launched: `terminate()` on a never-launched
+        // Process raises NSInvalidArgumentException, and `cancel()` can arrive
+        // at any time (Home after a failed start).
+        self.process = process
+        if cancelledFlag.load(ordering: .relaxed) { cancel(); return }
         thread.start()
     }
 
     func cancel() {
         cancelledFlag.store(true, ordering: .relaxed)
-        process?.terminate() // closes stdout → the reader loop sees EOF and stops
+        // Kill the whole tree: the executable is often a wrapper (podman,
+        // colima) whose `ssh` child would otherwise survive, hold the pipes'
+        // write ends open, and leave the reader threads blocked for good.
+        if let p = process, p.isRunning {
+            ProcessTree.signal(p.processIdentifier, SIGTERM)
+        }
         markFinished()
     }
 

--- a/Sources/SpaceMatters/Scanner/ContainerEngine.swift
+++ b/Sources/SpaceMatters/Scanner/ContainerEngine.swift
@@ -156,7 +156,8 @@ enum ContainerQueries {
         }
     }
 
-    private static func cleanCommand(_ raw: String) -> String {
+    /// Internal (not private) so tests can pin the layer-command cleanup.
+    static func cleanCommand(_ raw: String) -> String {
         var s = raw
         // Strip the buildkit/buildah arg prefix like "|3 KEY=v ... /bin/sh -c ".
         if let range = s.range(of: "/bin/sh -c ") { s = String(s[range.upperBound...]) }
@@ -167,10 +168,15 @@ enum ContainerQueries {
     // MARK: helpers
 
     private static func jsonArray(_ engine: ContainerEngine, _ args: [String]) -> [[String: Any]]? {
-        guard let json = VMProbe.capture(engine.executable, args),
-              let data = json.data(using: .utf8) else { return nil }
+        guard let json = VMProbe.capture(engine.executable, args) else { return nil }
+        return parseJSONArray(json)
+    }
+
+    /// Parse `--format json` output: a JSON array, or JSONL (one object per
+    /// line — some podman/docker commands emit that). Internal for tests.
+    static func parseJSONArray(_ json: String) -> [[String: Any]]? {
+        guard let data = json.data(using: .utf8) else { return nil }
         if let arr = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] { return arr }
-        // Some commands emit JSONL.
         var out: [[String: Any]] = []
         for line in json.split(whereSeparator: \.isNewline) {
             if let d = line.data(using: .utf8), let obj = try? JSONSerialization.jsonObject(with: d) as? [String: Any] {
@@ -200,7 +206,8 @@ enum ContainerQueries {
 
     /// Parse a docker-style human size ("1.2GB", "512MB", "0B") to bytes. Decimal
     /// units, matching docker's own output. Returns 0 for anything unrecognised.
-    private static func parseHumanSize(_ raw: String) -> Int64 {
+    /// Internal (not private) so tests can pin it — it drives the Reclaim button.
+    static func parseHumanSize(_ raw: String) -> Int64 {
         let s = raw.trimmingCharacters(in: .whitespaces)
         let units: [(String, Double)] = [
             ("TB", 1e12), ("GB", 1e9), ("MB", 1e6), ("kB", 1e3), ("KB", 1e3), ("B", 1),

--- a/Sources/SpaceMatters/Scanner/DirectoryScanner.swift
+++ b/Sources/SpaceMatters/Scanner/DirectoryScanner.swift
@@ -62,9 +62,16 @@ final class DirectoryScanner: ScanBackend {
     /// (matches `du`/df). Attribution mode (default) counts every link.
     private let exact: Bool
     private let linkLock = NSLock()
-    /// Inodes of multi-link files already counted (only `linkCount > 1` entries,
-    /// so this stays negligible even on huge trees).
-    private var seenInodes: Set<UInt64> = []
+    /// Identity of a multi-link file. Inode numbers are only unique per
+    /// filesystem — a multi-disk scan, or `/` spanning the System and Data
+    /// volumes, would collide on bare inodes and silently count files as zero.
+    private struct InodeKey: Hashable {
+        let dev: UInt32
+        let ino: UInt64
+    }
+    /// Multi-link files already counted (only `linkCount > 1` entries, so this
+    /// stays negligible even on huge trees).
+    private var seenInodes: Set<InodeKey> = []
 
     private static let bufferSize = 256 * 1024
 
@@ -317,7 +324,8 @@ final class DirectoryScanner: ScanBackend {
                 // sighting; later hardlinks contribute 0 bytes (still 1 file entry).
                 if exact && entry.linkCount > 1 {
                     linkLock.lock()
-                    let firstSighting = seenInodes.insert(entry.fileID).inserted
+                    let firstSighting = seenInodes
+                        .insert(InodeKey(dev: entry.deviceID, ino: entry.fileID)).inserted
                     linkLock.unlock()
                     if !firstSighting { effL = 0; effP = 0 }
                 }

--- a/Sources/SpaceMatters/Scanner/DirectoryScanner.swift
+++ b/Sources/SpaceMatters/Scanner/DirectoryScanner.swift
@@ -49,6 +49,10 @@ final class DirectoryScanner: ScanBackend {
     private var outstanding = 0
     private var finished = false
     private var cancelled = false
+    /// Workers that haven't exited yet. A cancel is cooperative — each worker
+    /// finishes its current directory first — so "cancelled" alone doesn't mean
+    /// the tree is quiescent; this reaching zero does.
+    private var activeWorkers = 0
 
     // Per-extension table (merged from each directory under its own lock).
     private let extLock = NSLock()
@@ -104,6 +108,7 @@ final class DirectoryScanner: ScanBackend {
         }
         outstanding = seeds.count
         if seeds.isEmpty { finished = true }
+        activeWorkers = workerCount
         cond.unlock()
 
         for i in 0..<workerCount {
@@ -127,12 +132,21 @@ final class DirectoryScanner: ScanBackend {
         return finished || cancelled
     }
 
-    /// Block the calling (background) thread until the scan finishes or is
-    /// cancelled. Used by `ScanController.invalidate` to await a subtree re-scan.
+    /// Block the calling (background) thread until the scan has finished or been
+    /// cancelled **and every worker has exited** — after this returns, no code
+    /// path of this scanner mutates the tree again. Used by
+    /// `ScanController.invalidate` to await a subtree re-scan, and to drain a
+    /// cancelled scan before its tree is mutated or torn down.
     func waitUntilFinished() {
         cond.lock()
-        while !finished && !cancelled { cond.wait() }
+        while (!finished && !cancelled) || activeWorkers > 0 { cond.wait() }
         cond.unlock()
+    }
+
+    /// True once the scan is over and every worker thread has exited.
+    var isDrained: Bool {
+        cond.lock(); defer { cond.unlock() }
+        return (finished || cancelled) && activeWorkers == 0
     }
 
     /// Raw per-extension table (copy under lock) — for reconciling the global
@@ -218,6 +232,14 @@ final class DirectoryScanner: ScanBackend {
     private func workerLoop() {
         let buffer = UnsafeMutableRawPointer.allocate(byteCount: Self.bufferSize, alignment: 16)
         defer { buffer.deallocate() }
+        // Signal exit on every return path so `waitUntilFinished`/`isDrained`
+        // only report quiescence once no worker can still touch the tree.
+        defer {
+            cond.lock()
+            activeWorkers -= 1
+            cond.broadcast()
+            cond.unlock()
+        }
 
         while true {
             cond.lock()

--- a/Sources/SpaceMatters/Scanner/FSAttr.swift
+++ b/Sources/SpaceMatters/Scanner/FSAttr.swift
@@ -10,6 +10,7 @@ enum FSAttr {
     // Common attribute bits (sys/attr.h)
     static let cmnReturnedAttrs: UInt32 = 0x8000_0000
     static let cmnName: UInt32          = 0x0000_0001
+    static let cmnDevID: UInt32         = 0x0000_0002 // dev_t, exact mode (inode dedup key)
     static let cmnObjType: UInt32       = 0x0000_0008
     static let cmnFileID: UInt32        = 0x0200_0000 // inode number (u_int64), exact mode
     static let cmnError: UInt32         = 0x2000_0000
@@ -44,6 +45,11 @@ struct BulkEntry {
     /// Inode number — only populated when the enumerator is `hardlinkAware`
     /// (exact counting mode); `0` otherwise.
     let fileID: UInt64
+    /// Device id of the filesystem holding the entry — `0` unless
+    /// `hardlinkAware`. Inode numbers are only unique per filesystem, so the
+    /// dedup key must be `(deviceID, fileID)`: a multi-volume scan (or `/`,
+    /// which spans the System and Data volumes) would otherwise collide.
+    let deviceID: UInt32
     /// Hardlink count — `0` unless `hardlinkAware`. `> 1` marks a file whose
     /// blocks are shared by several directory entries (dedup candidate).
     let linkCount: UInt32
@@ -69,7 +75,7 @@ func enumerateDirectory(
     // Requested only then, so the default (attribution) path packs an identical
     // buffer to before — the reads below are gated on the returned-attr masks.
     if hardlinkAware {
-        attrList.commonattr |= FSAttr.cmnFileID
+        attrList.commonattr |= FSAttr.cmnDevID | FSAttr.cmnFileID
         attrList.fileattr |= FSAttr.fileLinkCount
     }
 
@@ -118,6 +124,13 @@ func enumerateDirectory(
                     nameLen = Int(rawLen) - 1 // strip trailing NUL
                 }
                 off += 8
+            }
+
+            // ATTR_CMN_DEVID (0x02) packs between NAME (0x01) and OBJTYPE (0x08).
+            var deviceID: UInt32 = 0
+            if commonReturned & FSAttr.cmnDevID != 0 {
+                deviceID = entry.loadUnaligned(fromByteOffset: off, as: UInt32.self)
+                off += 4
             }
 
             var objType: UInt32 = 0
@@ -174,6 +187,7 @@ func enumerateDirectory(
                     logicalSize: logical,
                     physicalSize: physical,
                     fileID: fileID,
+                    deviceID: deviceID,
                     linkCount: linkCount
                 ))
             }

--- a/Sources/SpaceMatters/Scanner/FSWatcher.swift
+++ b/Sources/SpaceMatters/Scanner/FSWatcher.swift
@@ -21,10 +21,24 @@ final class FSWatcher {
 
     func start() {
         guard stream == nil, !paths.isEmpty else { return }
+        // retain/release make the *stream* keep the watcher alive: without them
+        // a callback in flight on the private queue races `stop()` + the last
+        // release on the main thread, and `takeUnretainedValue` dereferences a
+        // freed object. With them, FSEvents holds its own +1 until the stream
+        // is destroyed, after any pending callback.
         var ctx = FSEventStreamContext(
             version: 0,
             info: Unmanaged.passUnretained(self).toOpaque(),
-            retain: nil, release: nil, copyDescription: nil
+            retain: { info in
+                guard let info else { return nil }
+                _ = Unmanaged<FSWatcher>.fromOpaque(info).retain()
+                return info
+            },
+            release: { info in
+                guard let info else { return }
+                Unmanaged<FSWatcher>.fromOpaque(info).release()
+            },
+            copyDescription: nil
         )
         let flags = UInt32(kFSEventStreamCreateFlagUseCFTypes | kFSEventStreamCreateFlagNoDefer)
         guard let stream = FSEventStreamCreate(

--- a/Sources/SpaceMatters/Scanner/KubernetesEngine.swift
+++ b/Sources/SpaceMatters/Scanner/KubernetesEngine.swift
@@ -155,7 +155,8 @@ enum K8sQueries {
 
     private static func rawPath(_ node: String) -> String { "/api/v1/nodes/\(node)/proxy/stats/summary" }
 
-    private static func parseNodeUsage(_ raw: String) -> [String: Int64] {
+    /// Internal (not private) so tests can pin the kubelet stats shape.
+    static func parseNodeUsage(_ raw: String) -> [String: Int64] {
         guard let data = raw.data(using: .utf8),
               let summary = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let pods = summary["pods"] as? [[String: Any]] else { return [:] }

--- a/Sources/SpaceMatters/Scanner/ScanBackend.swift
+++ b/Sources/SpaceMatters/Scanner/ScanBackend.swift
@@ -94,6 +94,9 @@ struct SSHTarget: Equatable {
         var args = ["-o", "BatchMode=yes", "-o", "StrictHostKeyChecking=accept-new", "-o", "ConnectTimeout=10"]
         if let port { args += ["-p", String(port)] }
         if let identityFile, !identityFile.isEmpty { args += ["-i", identityFile] }
+        // End of options: a host typed as `-oProxyCommand=…` must be treated as
+        // a (bad) host name, never parsed as an ssh option.
+        args.append("--")
         args.append(user.isEmpty ? host : "\(user)@\(host)")
         args.append(RemoteFind.command(rootPath: path, sudo: useSudo))
         return ("/usr/bin/ssh", args, path)

--- a/Sources/SpaceMatters/Util/ProcessRunner.swift
+++ b/Sources/SpaceMatters/Util/ProcessRunner.swift
@@ -118,11 +118,11 @@ enum ProcessRunner {
         let group = DispatchGroup()
         group.enter()
         DispatchQueue.global(qos: .userInitiated).async {
-            buffers.setOut(outPipe.fileHandleForReading.readDataToEndOfFile()); group.leave()
+            Self.drain(outPipe.fileHandleForReading) { buffers.appendOut($0) }; group.leave()
         }
         group.enter()
         DispatchQueue.global(qos: .userInitiated).async {
-            buffers.setErr(errPipe.fileHandleForReading.readDataToEndOfFile()); group.leave()
+            Self.drain(errPipe.fileHandleForReading) { buffers.appendErr($0) }; group.leave()
         }
 
         // Watchdog: SIGTERM the whole tree at the deadline (grandchildren like a
@@ -153,13 +153,24 @@ enum ProcessRunner {
         )
     }
 
+    /// Incremental read so a timeout snapshot still holds everything received so
+    /// far — `readDataToEndOfFile` would only publish at EOF, i.e. never when a
+    /// straggler keeps the pipe open, losing the whole output.
+    private static func drain(_ handle: FileHandle, _ sink: (Data) -> Void) {
+        while true {
+            let chunk = handle.availableData // blocks until data; empty == EOF
+            if chunk.isEmpty { return }
+            sink(chunk)
+        }
+    }
+
     /// stdout/stderr accumulators shared with the drain threads.
     private final class PipeBuffers: @unchecked Sendable {
         private let lock = NSLock()
         private var out = Data()
         private var err = Data()
-        func setOut(_ d: Data) { lock.lock(); out = d; lock.unlock() }
-        func setErr(_ d: Data) { lock.lock(); err = d; lock.unlock() }
+        func appendOut(_ d: Data) { lock.lock(); out.append(d); lock.unlock() }
+        func appendErr(_ d: Data) { lock.lock(); err.append(d); lock.unlock() }
         func snapshot() -> (Data, Data) { lock.lock(); defer { lock.unlock() }; return (out, err) }
     }
 }

--- a/Sources/SpaceMatters/Util/ProcessRunner.swift
+++ b/Sources/SpaceMatters/Util/ProcessRunner.swift
@@ -22,10 +22,45 @@ struct ProcessResult {
     }
 }
 
+/// Best-effort signalling of a process **and its whole descendant tree**.
+/// `Process.terminate` signals only the direct child: a wrapper (`podman`,
+/// `colima`) that fork/execs `ssh` would leave the grandchild alive, still
+/// holding the pipes' write ends open — so readers never see EOF and the
+/// caller blocks forever. Descendants are enumerated via `proc_listpids`
+/// (`PROC_PPID_ONLY`) before anyone is signalled.
+enum ProcessTree {
+    private static let PROC_PPID_ONLY: UInt32 = 6
+
+    static func children(of pid: pid_t) -> [pid_t] {
+        let bytes = proc_listpids(PROC_PPID_ONLY, UInt32(pid), nil, 0)
+        guard bytes > 0 else { return [] }
+        var buf = [pid_t](repeating: 0, count: Int(bytes) / MemoryLayout<pid_t>.stride + 16)
+        let filled = proc_listpids(PROC_PPID_ONLY, UInt32(pid), &buf,
+                                   Int32(buf.count * MemoryLayout<pid_t>.stride))
+        guard filled > 0 else { return [] }
+        return buf.prefix(Int(filled) / MemoryLayout<pid_t>.stride).filter { $0 > 0 }
+    }
+
+    /// Signal `pid` and every live descendant. The tree is collected before the
+    /// first kill (a dead parent re-parents its children away from us).
+    static func signal(_ pid: pid_t, _ sig: Int32) {
+        var all: [pid_t] = []
+        var frontier = [pid]
+        while let next = frontier.popLast() {
+            let kids = children(of: next)
+            all.append(contentsOf: kids)
+            frontier.append(contentsOf: kids)
+        }
+        for p in all { kill(p, sig) }
+        kill(pid, sig)
+    }
+}
+
 /// Runs external commands (`podman`, `kubectl`, `colima`…) with a **hard
 /// timeout** and cooperative cancellation. Every one-shot shell-out goes through
 /// here so an unreachable API server or a wedged VM can never freeze the UI: the
-/// process is terminated (SIGTERM, then SIGKILL) instead of blocking forever.
+/// whole process tree is terminated (SIGTERM, then SIGKILL) instead of blocking
+/// forever.
 ///
 /// Both pipes are drained on background threads to avoid the classic full-pipe
 /// deadlock (a chatty child that fills the pipe while we wait on exit).
@@ -60,7 +95,7 @@ enum ProcessRunner {
         } onCancel: {
             // Only a launched process can be terminated; the watchdog covers the
             // narrow window where launch hasn't happened yet.
-            if process.isRunning { process.terminate() }
+            if process.isRunning { ProcessTree.signal(process.processIdentifier, SIGTERM) }
         }
     }
 
@@ -73,39 +108,58 @@ enum ProcessRunner {
             return ProcessResult(stdout: Data(), stderr: Data("\(error)".utf8), exitCode: -1, timedOut: false)
         }
 
+        let pid = process.processIdentifier
+
         // Drain both pipes concurrently so the child never blocks on a full pipe.
-        var outData = Data(), errData = Data()
+        // Buffers live behind a lock: if an untracked descendant survives the
+        // kill with our pipe open, we return the partial data instead of
+        // blocking forever, and the straggler reader finishes in its own time.
+        let buffers = PipeBuffers()
         let group = DispatchGroup()
         group.enter()
         DispatchQueue.global(qos: .userInitiated).async {
-            outData = outPipe.fileHandleForReading.readDataToEndOfFile(); group.leave()
+            buffers.setOut(outPipe.fileHandleForReading.readDataToEndOfFile()); group.leave()
         }
         group.enter()
         DispatchQueue.global(qos: .userInitiated).async {
-            errData = errPipe.fileHandleForReading.readDataToEndOfFile(); group.leave()
+            buffers.setErr(errPipe.fileHandleForReading.readDataToEndOfFile()); group.leave()
         }
 
-        // Watchdog: SIGTERM at the deadline, SIGKILL shortly after if still alive.
+        // Watchdog: SIGTERM the whole tree at the deadline (grandchildren like a
+        // wrapper's `ssh` included), SIGKILL shortly after if still alive.
         let timedOut = Atomic<Bool>(false)
         let watchdog = DispatchWorkItem {
             guard process.isRunning else { return }
             timedOut.store(true, ordering: .relaxed)
-            process.terminate()
+            ProcessTree.signal(pid, SIGTERM)
             DispatchQueue.global().asyncAfter(deadline: .now() + 2) {
-                if process.isRunning { kill(process.processIdentifier, SIGKILL) }
+                if process.isRunning { ProcessTree.signal(pid, SIGKILL) }
             }
         }
         DispatchQueue.global().asyncAfter(deadline: .now() + timeout, execute: watchdog)
 
         process.waitUntilExit()
         watchdog.cancel()
-        group.wait() // ensure both readers finished before returning their buffers
+        // Both pipes EOF as soon as the tree is dead; the bounded wait only cuts
+        // off a double-forked daemon that outlived the kill with our pipe open.
+        _ = group.wait(timeout: .now() + 3)
 
+        let (outData, errData) = buffers.snapshot()
         return ProcessResult(
             stdout: outData,
             stderr: errData,
             exitCode: process.terminationStatus,
             timedOut: timedOut.load(ordering: .relaxed)
         )
+    }
+
+    /// stdout/stderr accumulators shared with the drain threads.
+    private final class PipeBuffers: @unchecked Sendable {
+        private let lock = NSLock()
+        private var out = Data()
+        private var err = Data()
+        func setOut(_ d: Data) { lock.lock(); out = d; lock.unlock() }
+        func setErr(_ d: Data) { lock.lock(); err = d; lock.unlock() }
+        func snapshot() -> (Data, Data) { lock.lock(); defer { lock.unlock() }; return (out, err) }
     }
 }

--- a/Sources/SpaceMatters/ViewModel/AppModel.swift
+++ b/Sources/SpaceMatters/ViewModel/AppModel.swift
@@ -32,8 +32,16 @@ final class AppModel {
         didHandleLaunch = true
         let args = CommandLine.arguments
         guard let idx = args.firstIndex(of: "--open"), idx + 1 < args.count else { return }
+        let path = args[idx + 1]
+        var isDir: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: path, isDirectory: &isDir), isDir.boolValue else {
+            // A typo'd path must not "succeed" as an empty scan — say so and
+            // stay on the splash.
+            FileHandle.standardError.write(Data("error: --open path is not a directory: \(path)\n".utf8))
+            return
+        }
         route = .filesystem
-        filesystem.scan(url: URL(fileURLWithPath: args[idx + 1]))
+        filesystem.scan(url: URL(fileURLWithPath: path))
     }
 
     // MARK: Filesystem mode

--- a/Sources/SpaceMatters/ViewModel/CleanupController.swift
+++ b/Sources/SpaceMatters/ViewModel/CleanupController.swift
@@ -44,6 +44,9 @@ final class CleanupController {
     }
 
     func load() {
+        // The model guards itself (same philosophy as DeletionGuardTests): a
+        // reload during a clean would reset rows/state under the operation.
+        guard state != .cleaning else { return }
         loadID += 1
         let id = loadID
         lastFreed = 0
@@ -117,6 +120,7 @@ final class CleanupController {
     func cleanSelected() async {
         guard state == .ready, !selectedRows.isEmpty else { return }
         state = .cleaning
+        let id = loadID
         let before = totalSelected
         let targets = selectedRows.map(\.item)
         let root = allowedRoot
@@ -130,9 +134,11 @@ final class CleanupController {
             let measure = await Task.detached(priority: .userInitiated) {
                 CleanupEngine.size(of: item)
             }.value
+            guard id == loadID else { return } // mode left/re-entered mid-clean
             apply(measure, to: item.id)
         }
 
+        guard id == loadID else { return } // don't stamp a newer session's state
         lastFailures = failures
         lastFreed = max(0, before - totalSelected)
         for idx in rows.indices { rows[idx].selected = false }

--- a/Sources/SpaceMatters/ViewModel/ContainerController.swift
+++ b/Sources/SpaceMatters/ViewModel/ContainerController.swift
@@ -16,10 +16,20 @@ final class ContainerController {
     private(set) var containers: [CContainer] = []
     private(set) var volumes: [CVolume] = []
 
+    /// Failure of the last cleanup action (timeout, engine refusal…), surfaced
+    /// as an alert — a prune that dies silently looks like a button that does
+    /// nothing.
+    private(set) var actionError: String?
+    /// Label of the cleanup action currently running; disables the others.
+    private(set) var runningAction: String?
+
     var expandedImages: Set<String> = []
     private(set) var layerCache: [String: [CLayer]] = [:]
 
     private var engine: ContainerEngine?
+    /// Superseded-load guard (same pattern as the Kubernetes and Cleanup modes):
+    /// a slow stale snapshot must never overwrite a newer engine's data.
+    @ObservationIgnored private var loadID = 0
 
     var imagesRow: CDFRow? { df.first { $0.type.lowercased().contains("image") } }
     var containersRow: CDFRow? { df.first { $0.type.lowercased().contains("container") } }
@@ -31,7 +41,11 @@ final class ContainerController {
         state = .loading
         df = []; images = []; containers = []; volumes = []
         expandedImages = []; layerCache = [:]
-        Task { await reload() }
+        actionError = nil
+        runningAction = nil
+        loadID += 1
+        let id = loadID
+        Task { await reload(id) }
     }
 
     func refresh() {
@@ -39,11 +53,17 @@ final class ContainerController {
         load(engine: engine)
     }
 
-    func stop() { /* no long-running work to cancel */ }
+    /// Leaving the mode: orphan any in-flight reload or action result so a slow
+    /// stale snapshot can't overwrite whatever the user looks at next.
+    func stop() {
+        loadID += 1
+        runningAction = nil
+    }
 
-    private func reload() async {
+    private func reload(_ id: Int) async {
         guard let engine else { return }
         let snapshot = await Task.detached(priority: .userInitiated) { ContainerQueries.fetchAll(engine) }.value
+        guard id == loadID else { return } // superseded (engine switched / mode left)
         df = snapshot.df
         images = snapshot.images.sorted { $0.size > $1.size }
         containers = snapshot.containers.sorted { $0.size > $1.size }
@@ -66,27 +86,43 @@ final class ContainerController {
 
     private func loadLayersIfNeeded(_ image: CImage) {
         guard layerCache[image.id] == nil, let engine else { return }
+        let id = loadID
         Task {
             let layers = await Task.detached(priority: .userInitiated) {
                 ContainerQueries.history(engine, imageID: image.id)
             }.value
+            guard id == loadID else { return }
             layerCache[image.id] = layers
         }
     }
 
     // MARK: Cleanup actions
+    //
+    // All destructive, so none is fire-and-forget: they run with a long deadline
+    // (a prune can walk tens of GB — the default 20 s would SIGKILL it mid-way)
+    // and any failure or timeout surfaces in `actionError`.
 
-    func removeImage(_ image: CImage) { run(["rmi", "-f", image.id]) }
-    func pruneImages() { run(["image", "prune", "-a", "-f"]) }
-    func pruneContainers() { run(["container", "prune", "-f"]) }
-    func pruneVolumes() { run(["volume", "prune", "-f"]) }
-    func removeContainer(_ container: CContainer) { run(["rm", "-f", container.id]) }
+    /// No `-f`: a forced `rmi` also stops and deletes the containers using the
+    /// image. If it's in use the engine refuses and the refusal is shown as-is.
+    func removeImage(_ image: CImage) { run("Remove image", ["rmi", image.id]) }
+    func pruneImages() { run("Prune images", ["image", "prune", "-a", "-f"]) }
+    func pruneContainers() { run("Prune containers", ["container", "prune", "-f"]) }
+    func pruneVolumes() { run("Prune volumes", ["volume", "prune", "-f"]) }
+    func removeContainer(_ container: CContainer) { run("Remove container", ["rm", "-f", container.id]) }
 
-    private func run(_ args: [String]) {
-        guard let engine else { return }
+    func clearActionError() { actionError = nil }
+
+    private func run(_ label: String, _ args: [String]) {
+        guard let engine, runningAction == nil else { return }
+        runningAction = label
+        actionError = nil
+        let id = loadID
         Task {
-            _ = await Task.detached(priority: .userInitiated) { VMProbe.capture(engine.executable, args) }.value
-            await reload()
+            let result = await ProcessRunner.run(engine.executable, args, timeout: 600)
+            guard id == loadID else { return } // mode was left meanwhile
+            runningAction = nil
+            if !result.ok { actionError = "\(label) failed: \(result.diagnostic)" }
+            await reload(id)
         }
     }
 }

--- a/Sources/SpaceMatters/ViewModel/ScanController.swift
+++ b/Sources/SpaceMatters/ViewModel/ScanController.swift
@@ -119,6 +119,53 @@ final class ScanController {
 
     private var scanner: (any ScanBackend)?
 
+    // MARK: Structural integrity
+
+    /// Monotonic tree generation, bumped whenever the tree is replaced or torn
+    /// down (`startBackend`, `goHome`). Structural operations (`remove`,
+    /// `invalidate`) capture it before suspending and re-check it after every
+    /// `await`: if it moved, the tree they were operating on is gone — abort
+    /// without touching the one that replaced it.
+    @ObservationIgnored private var treeEpoch: UInt64 = 0
+    /// True while a `remove`/`invalidate` is suspended mid-flight. Structural
+    /// operations are mutually exclusive — concurrent tree surgery would
+    /// subtract aggregates out from under each other. Mass-delete (⌘⌫) awaits
+    /// each removal sequentially, so this never turns it away.
+    @ObservationIgnored private var structuralOpActive = false
+    /// True from Stop until the cancelled scanner's workers have actually
+    /// exited. The cancel is cooperative — workers finish their current
+    /// directory first — so until then they still mutate the tree and
+    /// structural operations must stay refused.
+    @ObservationIgnored private var drainingCancelledScan = false
+    /// The sub-scanner of an in-flight `invalidate`, so a Rescan/Home can
+    /// cancel it instead of letting it keep re-scanning a subtree nobody
+    /// displays anymore.
+    @ObservationIgnored private var activeSubScan: DirectoryScanner?
+
+    /// Keep an outgoing tree and its scanner alive until the workers have
+    /// exited, then let both go on a background thread. Workers propagate sizes
+    /// up `unowned` parent chains, so freeing the old tree from under them
+    /// would trap; releasing off-main also spares the UI the deallocation of a
+    /// multi-million-node tree.
+    private func releaseAfterDrain(scanner: (any ScanBackend)?, root: FSNode?) {
+        guard scanner != nil || root != nil else { return }
+        Task.detached(priority: .utility) {
+            if let ds = scanner as? DirectoryScanner { ds.waitUntilFinished() }
+            withExtendedLifetime(root) {}
+            withExtendedLifetime(scanner) {}
+        }
+    }
+
+    /// Strong references to a node's ancestor chain. `parent` links are
+    /// `unowned`; a structural operation holds this across its suspensions so a
+    /// concurrent Rescan/Home can never free the ancestors it walks on resume.
+    private static func retainedAncestors(of node: FSNode) -> [FSNode] {
+        var chain: [FSNode] = []
+        var p = node.parent
+        while let n = p { chain.append(n); p = n.parent }
+        return chain
+    }
+
     // MARK: Live disk watching (SPEC-04)
 
     /// True once the disk has changed *enough* under the scanned tree to be worth
@@ -275,7 +322,17 @@ final class ScanController {
         isHost: Bool,
         nodePaths: [ObjectIdentifier: String]
     ) {
+        // The old tree is being replaced: abort in-flight structural operations
+        // (they re-check the epoch after each await), stop a sub-scan that would
+        // otherwise keep re-scanning an orphaned subtree, and keep the outgoing
+        // tree alive until its workers have exited.
+        treeEpoch &+= 1
+        activeSubScan?.cancel()
+        let oldScanner = self.scanner
+        let oldRoot = self.root
         cancel()
+        drainingCancelledScan = false // the new tree isn't the one draining
+        releaseAfterDrain(scanner: oldScanner, root: oldRoot)
 
         self.root = root
         self.zoomRoot = root
@@ -293,6 +350,7 @@ final class ScanController {
 
         sortCache.removeAll()
         fileCache.removeAll()
+        layoutCache = TreemapLayout.Cache() // its entries retain old-tree nodes
         self.nodePaths = nodePaths
         stopWatching()
         self.watchPaths = isHost ? Array(nodePaths.values) : []
@@ -315,6 +373,16 @@ final class ScanController {
         phase = .cancelled
         refresh(final: true)
         stopTimer()
+        // The cancel is cooperative: workers finish their current directory
+        // before exiting. Keep structural ops refused until they all have.
+        if let ds = scanner as? DirectoryScanner, !ds.isDrained {
+            drainingCancelledScan = true
+            let epoch = treeEpoch
+            Task { @MainActor [weak self] in
+                await Task.detached(priority: .userInitiated) { ds.waitUntilFinished() }.value
+                if let self, self.treeEpoch == epoch { self.drainingCancelledScan = false }
+            }
+        }
     }
 
     func rescan() {
@@ -326,7 +394,11 @@ final class ScanController {
 
     /// Discard the current scan and return to the disk-selection splash.
     func goHome() {
-        scanner?.cancel()
+        treeEpoch &+= 1
+        activeSubScan?.cancel()
+        let oldScanner = scanner
+        let oldRoot = root
+        oldScanner?.cancel()
         stopTimer()
         stopWatching()
         scanDate = nil
@@ -349,6 +421,9 @@ final class ScanController {
         totalLogical = 0; totalPhysical = 0; fileCount = 0; dirCount = 0; errorCount = 0
         filesPerSecond = 0; elapsed = 0; extRows = []
         sortCache.removeAll(); fileCache.removeAll(); nodePaths.removeAll()
+        layoutCache = TreemapLayout.Cache() // don't retain the whole old tree on the splash
+        drainingCancelledScan = false
+        releaseAfterDrain(scanner: oldScanner, root: oldRoot)
         bump()
     }
 
@@ -689,8 +764,18 @@ final class ScanController {
     /// must not rely on every entry point remembering to.
     @discardableResult
     func remove(directory node: FSNode, permanently: Bool) async -> Bool {
-        guard isHostScan, phase != .scanning,
-              node.parent != nil, let path = path(for: node) else { return false }
+        // `root != nil` must come before any dereference of `node` — a task
+        // scheduled just before Home could otherwise walk a freed parent chain.
+        guard isHostScan, phase != .scanning, !drainingCancelledScan, !structuralOpActive,
+              root != nil, node.parent != nil, let path = path(for: node) else { return false }
+        structuralOpActive = true
+        defer { structuralOpActive = false }
+        // Hold the ancestors strongly and re-check the epoch after every
+        // suspension: a Rescan/Home while we're off-actor must neither free the
+        // chain we walk on resume nor let us mutate the tree that replaced ours.
+        let epoch = treeEpoch
+        let ancestors = Self.retainedAncestors(of: node)
+        defer { withExtendedLifetime(ancestors) {} }
         let rowID = RowID.dir(ObjectIdentifier(node))
         deletingRows.insert(rowID)
         defer { deletingRows.remove(rowID) }
@@ -698,13 +783,15 @@ final class ScanController {
         // A6: capture the subtree's per-extension breakdown *before* deleting it
         // (off the main thread) so the File-types panel can be corrected after.
         // Not stored per node, so it must be re-enumerated from disk while it exists.
-        let extDelta: [ExtKey: ExtStat] = isHostScan
-            ? await Task.detached(priority: .userInitiated) {
-                DirectoryScanner.subtreeExtensions(path: path)
-              }.value
-            : [:]
+        let extDelta: [ExtKey: ExtStat] = await Task.detached(priority: .userInitiated) {
+            DirectoryScanner.subtreeExtensions(path: path)
+        }.value
+        guard epoch == treeEpoch else { return false }
 
         guard await Self.diskRemove(path: path, permanently: permanently) else { return false }
+        // Disk removal happened, but the tree it belonged to is gone — the
+        // replacement scan observes the deletion by itself.
+        guard epoch == treeEpoch else { return true }
         applyDirectoryRemoval(node)
         if !extDelta.isEmpty {
             scanner?.subtractExtensions(extDelta)
@@ -769,12 +856,18 @@ final class ScanController {
     /// Same safety guards as `remove(directory:)`.
     @discardableResult
     func remove(file: FileItem, parent: FSNode, permanently: Bool) async -> Bool {
-        guard isHostScan, phase != .scanning,
-              let path = path(forFile: file, parent: parent) else { return false }
+        guard isHostScan, phase != .scanning, !drainingCancelledScan, !structuralOpActive,
+              root != nil, let path = path(forFile: file, parent: parent) else { return false }
+        structuralOpActive = true
+        defer { structuralOpActive = false }
+        let epoch = treeEpoch
+        let ancestors = Self.retainedAncestors(of: parent)
+        defer { withExtendedLifetime(ancestors) {} }
         let rowID = RowID.file(ObjectIdentifier(parent), file.name)
         deletingRows.insert(rowID)
         defer { deletingRows.remove(rowID) }
         guard await Self.diskRemove(path: path, permanently: permanently) else { return false }
+        guard epoch == treeEpoch else { return true } // deleted on disk; tree is gone
 
         parent.adjustDirectFiles(logical: -file.logical, physical: -file.physical, count: -1)
         var p: FSNode? = parent
@@ -817,7 +910,16 @@ final class ScanController {
     /// while no full scan is running (its atomics would collide).
     @discardableResult
     func invalidate(subtree node: FSNode) async -> Bool {
-        guard isHostScan, phase != .scanning, node.isDirectory, let path = path(for: node) else { return false }
+        guard isHostScan, phase != .scanning, !drainingCancelledScan, !structuralOpActive,
+              root != nil, node.isDirectory, let path = path(for: node) else { return false }
+        structuralOpActive = true
+        defer { structuralOpActive = false }
+        // Same epoch/ancestor discipline as `remove(directory:)`. The strong
+        // ancestors additionally keep the sub-scan's upward propagation safe on
+        // its worker threads if a Rescan replaces the tree mid-flight.
+        let epoch = treeEpoch
+        let ancestors = Self.retainedAncestors(of: node)
+        defer { withExtendedLifetime(ancestors) {} }
 
         // OLD subtree snapshot (aggregates, folder count, and per-extension bytes
         // from disk — the same source as the fresh tally, so they reconcile exactly).
@@ -828,6 +930,7 @@ final class ScanController {
         let oldExt = await Task.detached(priority: .userInitiated) {
             DirectoryScanner.subtreeExtensions(path: path)
         }.value
+        guard epoch == treeEpoch else { return false }
 
         // Capture navigation state that points *into* the subtree — its descendant
         // nodes are about to be replaced by fresh objects — then drop the strong
@@ -856,8 +959,13 @@ final class ScanController {
         // the parent chain stays intact all the way to the real root.
         let skip = DirectoryScanner.recommendedSkipPaths(seedPaths: [path])
         let sub = DirectoryScanner(root: node, seeds: [.init(path: path, node: node)], skipPaths: skip, exact: countingMode == .exact)
+        activeSubScan = sub
         sub.start()
         await Task.detached(priority: .userInitiated) { sub.waitUntilFinished() }.value
+        activeSubScan = nil
+        // Torn down mid-re-scan (Rescan/Home): the half-reconciled subtree is
+        // detached from anything visible; let it be freed with the old tree.
+        guard epoch == treeEpoch else { return false }
 
         // Reconcile the global File-types table: subtract the subtree's old
         // per-extension bytes, add the fresh ones. EXACT for the deletion path
@@ -963,8 +1071,14 @@ final class ScanController {
         }
         dirtyPaths.removeAll()
         diskChanged = false
+        let epoch = treeEpoch
         for p in roots {
-            if let node = nearestNode(toPath: p) { await invalidate(subtree: node) }
+            guard epoch == treeEpoch else { return } // Rescan/Home mid-refresh
+            if let node = nearestNode(toPath: p), !(await invalidate(subtree: node)) {
+                // Refused (e.g. a delete is in flight) — keep the path dirty so
+                // the next Refresh retries instead of silently forgetting it.
+                dirtyPaths.insert(p)
+            }
         }
         scanDate = Date()
         // Re-baseline the budget so the banner measures drift from *this* refresh.

--- a/Sources/SpaceMatters/ViewModel/ScanController.swift
+++ b/Sources/SpaceMatters/ViewModel/ScanController.swift
@@ -277,7 +277,14 @@ final class ScanController {
 
     /// Scan inside a Podman/Colima VM (streamed `find` over SSH).
     func scanVM(machine: VMMachine, scope: VMScope) {
-        guard machine.running else { return }
+        guard machine.running else {
+            // The route already switched to the result view: a silent return
+            // would show an unexplained empty screen if the VM stopped between
+            // detection and the click.
+            failureMessage = "\(machine.runtime.rawValue) “\(machine.name)” is not running — start it and scan again."
+            phase = .failed
+            return
+        }
         lastVolumes = []
         lastVM = (machine, scope)
         let cmd = VMProbe.scanCommand(machine: machine, scope: scope)
@@ -475,6 +482,9 @@ final class ScanController {
     /// must not re-sort every expanded folder's files on each evaluation.
     private struct FileListing { let count: Int64; let metric: SizeMetric; let items: [FileItem] }
     @ObservationIgnored private var fileCache: [ObjectIdentifier: FileListing] = [:]
+    /// Directories whose file listing is being enumerated off-main right now
+    /// (prevents duplicate walks while `visibleRows()` polls at 10 Hz).
+    @ObservationIgnored private var fileListingsInFlight: Set<ObjectIdentifier> = []
     /// Resolved paths for seed (root/volume) nodes, so any node's full path can be
     /// rebuilt on demand without storing a path on every node.
     @ObservationIgnored private var nodePaths: [ObjectIdentifier: String] = [:]
@@ -565,27 +575,48 @@ final class ScanController {
             return resorted
         }
 
-        var items: [FileItem] = []
-        if count > 0, let dirPath = path(for: node) {
-            let fd = open(dirPath, O_RDONLY | O_DIRECTORY)
-            if fd >= 0 {
-                let bufSize = 64 * 1024
-                let buf = UnsafeMutableRawPointer.allocate(byteCount: bufSize, alignment: 16)
-                enumerateDirectory(fd: fd, buffer: buf, bufferSize: bufSize) { entry in
-                    guard !entry.isDirectory else { return }
-                    let name = String(decoding: UnsafeRawBufferPointer(start: entry.name, count: entry.nameLength), as: UTF8.self)
-                    items.append(FileItem(name: name, logical: entry.logicalSize, physical: entry.physicalSize))
-                }
-                buf.deallocate()
-                close(fd)
+        // Cache miss: enumerate off the main actor — a 100k-file folder or a slow
+        // network volume must not beach-ball the UI — and repaint when it lands.
+        // Callers get an empty placeholder for the frame or two it takes.
+        guard count > 0, let dirPath = path(for: node) else {
+            fileCache[key] = FileListing(count: count, metric: metric, items: [])
+            return []
+        }
+        guard !fileListingsInFlight.contains(key) else { return [] }
+        fileListingsInFlight.insert(key)
+        let epoch = treeEpoch
+        let m = metric
+        Task { @MainActor in
+            var items = await Task.detached(priority: .userInitiated) {
+                Self.enumerateFiles(dirPath: dirPath)
+            }.value
+            self.fileListingsInFlight.remove(key)
+            guard epoch == self.treeEpoch else { return }
+            if items.count > Self.maxFilesPerFolder {
+                items.sort { $0.physical > $1.physical }
+                items.removeLast(items.count - Self.maxFilesPerFolder)
             }
+            items.sort { $0.size(m) > $1.size(m) }
+            self.fileCache[key] = FileListing(count: node.directFileCount, metric: m, items: items)
+            self.bump()
         }
-        if items.count > Self.maxFilesPerFolder {
-            items.sort { $0.physical > $1.physical }
-            items.removeLast(items.count - Self.maxFilesPerFolder)
+        return []
+    }
+
+    /// Blocking directory read behind `filesIn` — runs on a detached task.
+    nonisolated private static func enumerateFiles(dirPath: String) -> [FileItem] {
+        var items: [FileItem] = []
+        let fd = open(dirPath, O_RDONLY | O_DIRECTORY)
+        guard fd >= 0 else { return items }
+        let bufSize = 64 * 1024
+        let buf = UnsafeMutableRawPointer.allocate(byteCount: bufSize, alignment: 16)
+        enumerateDirectory(fd: fd, buffer: buf, bufferSize: bufSize) { entry in
+            guard !entry.isDirectory else { return }
+            let name = String(decoding: UnsafeRawBufferPointer(start: entry.name, count: entry.nameLength), as: UTF8.self)
+            items.append(FileItem(name: name, logical: entry.logicalSize, physical: entry.physicalSize))
         }
-        items.sort { $0.size(metric) > $1.size(metric) }
-        fileCache[key] = FileListing(count: count, metric: metric, items: items)
+        buf.deallocate()
+        close(fd)
         return items
     }
 
@@ -1003,6 +1034,9 @@ final class ScanController {
         refreshTotals()
         extRows = scanner?.snapshotExtensions(metric: metric, limit: 250) ?? extRows
         bump()
+        // The rebuilt nodes have fresh identities: an active search would keep
+        // matching the freed objects and silently drop this subtree's hits.
+        if isSearching { setSearch(searchQuery) }
         return true
     }
 

--- a/Sources/SpaceMatters/ViewModel/ScanController.swift
+++ b/Sources/SpaceMatters/ViewModel/ScanController.swift
@@ -470,8 +470,10 @@ final class ScanController {
     @ObservationIgnored private var sortCacheMetric: SizeMetric = .physical
     /// Cached file listing per directory, tagged with the directory's direct-file
     /// count so it stays valid during a live scan and only re-enumerates the disk
-    /// when that directory's contents actually changed.
-    private struct FileListing { let count: Int64; let items: [FileItem] }
+    /// when that directory's contents actually changed. Items are kept sorted by
+    /// `metric` (tagged too): `visibleRows()` runs at 10 Hz during a scan and
+    /// must not re-sort every expanded folder's files on each evaluation.
+    private struct FileListing { let count: Int64; let metric: SizeMetric; let items: [FileItem] }
     @ObservationIgnored private var fileCache: [ObjectIdentifier: FileListing] = [:]
     /// Resolved paths for seed (root/volume) nodes, so any node's full path can be
     /// rebuilt on demand without storing a path on every node.
@@ -555,7 +557,13 @@ final class ScanController {
         // Valid as long as the folder's file count is unchanged — true across the
         // 10 Hz refresh during a scan (a folder's files are set once, atomically)
         // and forever after it.
-        if let cached = fileCache[key], cached.count == count { return cached.items }
+        if let cached = fileCache[key], cached.count == count {
+            if cached.metric == metric { return cached.items }
+            // Metric flipped: re-sort the cached listing, no disk I/O.
+            let resorted = cached.items.sorted { $0.size(metric) > $1.size(metric) }
+            fileCache[key] = FileListing(count: count, metric: metric, items: resorted)
+            return resorted
+        }
 
         var items: [FileItem] = []
         if count > 0, let dirPath = path(for: node) {
@@ -576,7 +584,8 @@ final class ScanController {
             items.sort { $0.physical > $1.physical }
             items.removeLast(items.count - Self.maxFilesPerFolder)
         }
-        fileCache[key] = FileListing(count: count, items: items)
+        items.sort { $0.size(metric) > $1.size(metric) }
+        fileCache[key] = FileListing(count: count, metric: metric, items: items)
         return items
     }
 
@@ -687,7 +696,7 @@ final class ScanController {
             guard isOpen else { return }
 
             let kids = sortedChildren(node)
-            let files = filesIn(node).sorted { $0.size(metric) > $1.size(metric) }
+            let files = filesIn(node) // pre-sorted by the current metric (cached)
             let childMax = max(kids.first?.size(metric) ?? 0, files.first?.size(metric) ?? 0, 1)
 
             // Merge folders + files by size, biggest first.

--- a/Sources/SpaceMatters/Views/ContainerResultView.swift
+++ b/Sources/SpaceMatters/Views/ContainerResultView.swift
@@ -35,6 +35,16 @@ struct ContainerResultView: View {
         .background(theme.windowBackground)
         .alert(item: $confirmPrune) { kind in pruneAlert(kind) }
         .alert(item: $confirmRemove) { image in removeAlert(image) }
+        .alert("Action failed", isPresented: actionErrorShown) {
+            Button("OK", role: .cancel) { controller.clearActionError() }
+        } message: {
+            Text(controller.actionError ?? "")
+        }
+    }
+
+    private var actionErrorShown: Binding<Bool> {
+        Binding(get: { controller.actionError != nil },
+                set: { if !$0 { controller.clearActionError() } })
     }
 
     // MARK: Toolbar
@@ -55,6 +65,12 @@ struct ContainerResultView: View {
             Text("\(controller.engineName) containers")
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundStyle(theme.textPrimary)
+
+            if let action = controller.runningAction {
+                ProgressView().controlSize(.small)
+                Text("\(action)…")
+                    .font(.system(size: 11)).foregroundStyle(theme.textSecondary)
+            }
 
             Spacer()
 
@@ -104,6 +120,8 @@ struct ContainerResultView: View {
                         .background(Capsule().fill(Color(hex: 0xE0915A)))
                 }
                 .buttonStyle(.plain)
+                .disabled(controller.runningAction != nil)
+                .opacity(controller.runningAction != nil ? 0.5 : 1)
             } else {
                 Text("nothing to reclaim")
                     .font(.system(size: 10)).foregroundStyle(theme.textSecondary.opacity(0.7))
@@ -192,9 +210,14 @@ struct ContainerResultView: View {
     }
 
     private func removeAlert(_ image: CImage) -> Alert {
-        Alert(
+        // `rmi` is deliberately not forced: on an in-use image the engine
+        // refuses instead of tearing down the containers that use it.
+        let message = image.inUse
+            ? "“\(image.name)” is used by at least one container, so \(controller.engineName) will refuse to delete it. Remove those containers first."
+            : "“\(image.name)” (\(Format.bytes(image.size))) will be deleted."
+        return Alert(
             title: Text("Remove image?"),
-            message: Text("“\(image.name)” (\(Format.bytes(image.size))) will be deleted."),
+            message: Text(message),
             primaryButton: .destructive(Text("Remove")) { controller.removeImage(image) },
             secondaryButton: .cancel()
         )

--- a/Sources/SpaceMatters/Views/DirectoryTable.swift
+++ b/Sources/SpaceMatters/Views/DirectoryTable.swift
@@ -83,6 +83,7 @@ struct DirectoryTable: NSViewRepresentable {
         weak var table: MacDirTableView?
         private(set) var rows: [ScanController.OutlineRow] = []
         private var rowIDs: [ScanController.RowID] = []
+        private var rowIndexByID: [ScanController.RowID: Int] = [:]
         /// Suppress delegate → controller pushes while *we* mutate the selection.
         private var applyingSelection = false
         private var hoveredRow = -1
@@ -106,6 +107,13 @@ struct DirectoryTable: NSViewRepresentable {
             let structureChanged = newIDs != rowIDs
             rows = newRows
             rowIDs = newIDs
+            if structureChanged {
+                // O(1) id→row projection for selection sync and reveal-scroll: a
+                // linear firstIndex per selected id turns ⌘A on a big list into
+                // O(N²) per update.
+                rowIndexByID = Dictionary(newIDs.enumerated().map { ($1, $0) },
+                                          uniquingKeysWith: { first, _ in first })
+            }
 
             applyingSelection = true
             if structureChanged {
@@ -132,7 +140,7 @@ struct DirectoryTable: NSViewRepresentable {
 
         private func applySelectionFromController() {
             guard let table else { return }
-            let want = IndexSet(controller.selectedRowIDs.compactMap { rowIDs.firstIndex(of: $0) })
+            let want = IndexSet(controller.selectedRowIDs.compactMap { rowIndexByID[$0] })
             if table.selectedRowIndexes != want {
                 table.selectRowIndexes(want, byExtendingSelection: false)
             }
@@ -140,7 +148,7 @@ struct DirectoryTable: NSViewRepresentable {
 
         private func scrollToRevealTargetIfNeeded() {
             guard let target = controller.revealTarget, let table else { return }
-            if let idx = rowIDs.firstIndex(of: .dir(ObjectIdentifier(target))) {
+            if let idx = rowIndexByID[.dir(ObjectIdentifier(target))] {
                 table.scrollRowToVisible(idx)
             }
             // Clear async to avoid mutating observable state during a view update.

--- a/Sources/SpaceMatters/Views/TreemapMetalRenderer.swift
+++ b/Sources/SpaceMatters/Views/TreemapMetalRenderer.swift
@@ -149,6 +149,10 @@ final class TreemapMetalRenderer {
         rpd.depthAttachment.loadAction = .clear
         rpd.depthAttachment.storeAction = .dontCare
         rpd.depthAttachment.clearDepth = 1
+        // The transient attachments may be larger than the drawable (grow-only
+        // allocation on non-memoryless GPUs): clamp the pass to the drawable.
+        rpd.renderTargetWidth = drawable.texture.width
+        rpd.renderTargetHeight = drawable.texture.height
 
         guard let cmd = queue.makeCommandBuffer(),
               let enc = cmd.makeRenderCommandEncoder(descriptor: rpd) else {
@@ -192,7 +196,20 @@ final class TreemapMetalRenderer {
 
     private func ensureAttachments(_ size: CGSize) {
         guard depthTexture == nil || attachmentSize != size else { return }
-        let w = max(1, Int(size.width)), h = max(1, Int(size.height))
+        var w = max(1, Int(size.width)), h = max(1, Int(size.height))
+        // Memoryless attachments (Apple Silicon TBDR) cost nothing to recreate.
+        // On `.private` (Intel/eGPU) they are real VRAM allocations, recreated
+        // twice per frame of a resize drag: round up to 256 px steps and never
+        // shrink, so a drag reallocates a handful of times instead; the render
+        // pass is clamped to the drawable via renderTargetWidth/Height.
+        if transientStorage == .private {
+            w = (w + 255) & ~255
+            h = (h + 255) & ~255
+            if let t = depthTexture, t.width >= w, t.height >= h {
+                attachmentSize = size
+                return
+            }
+        }
 
         let dd = MTLTextureDescriptor.texture2DDescriptor(
             pixelFormat: .depth32Float, width: w, height: h, mipmapped: false)

--- a/Sources/SpaceMatters/Views/TreemapView.swift
+++ b/Sources/SpaceMatters/Views/TreemapView.swift
@@ -15,7 +15,10 @@ import QuartzCore
 struct TreemapView: View {
     @Bindable var controller: ScanController
     @Environment(\.theme) private var theme
-    @State private var hover: HoverInfo?
+    /// Hover lives in its own observable box so a mouse move only re-evaluates
+    /// the pill overlay — not this whole body (which would re-diff the
+    /// representable's inputs and recompute the a11y summary per event).
+    @State private var hoverModel = HoverModel()
 
     var body: some View {
         // Reading these establishes SwiftUI observation: when any changes, `body`
@@ -32,13 +35,10 @@ struct TreemapView: View {
             searchMatchIDs: controller.searchMatchIDs,
             highlightVersion: controller.highlightVersion,
             isDark: theme.isDark,
-            onHover: { hover = $0 }
+            onHover: { [hoverModel] in hoverModel.info = $0 }
         )
         .overlay(alignment: .bottomLeading) {
-            if let hover {
-                HoverLabel(title: hover.title, isDirectory: hover.isDirectory, sizeText: hover.sizeText)
-                    .padding(8).allowsHitTesting(false)
-            }
+            HoverPill(model: hoverModel)
         }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("Treemap")
@@ -64,6 +64,23 @@ struct HoverInfo: Equatable {
     let title: String
     let isDirectory: Bool
     let sizeText: String
+}
+
+/// Isolates the hover state (see `TreemapView.hoverModel`).
+@MainActor @Observable
+final class HoverModel {
+    var info: HoverInfo?
+}
+
+/// The only view that observes `HoverModel.info` — mouse moves invalidate it alone.
+private struct HoverPill: View {
+    let model: HoverModel
+    var body: some View {
+        if let hover = model.info {
+            HoverLabel(title: hover.title, isDirectory: hover.isDirectory, sizeText: hover.sizeText)
+                .padding(8).allowsHitTesting(false)
+        }
+    }
 }
 
 /// Bridges the AppKit `TreemapNSView` into SwiftUI. `updateNSView` pushes the
@@ -187,7 +204,10 @@ final class TreemapNSView: NSView, CALayerDelegate {
             ml.pixelFormat = .bgra8Unorm            // non-sRGB: store sRGB values as-is → matches CG
             ml.framebufferOnly = true
             ml.isOpaque = true
-            ml.presentsWithTransaction = true       // atomic present with bounds during live-resize
+            // `presentsWithTransaction` is turned on only while resizing (see
+            // viewWillStartLiveResize / setFrameSize): the synchronous commit +
+            // waitUntilScheduled it implies must not tax every ordinary frame.
+            ml.presentsWithTransaction = false
             ml.colorspace = CGColorSpace(name: CGColorSpace.sRGB)
             self.renderer = renderer
             self.metalLayer = ml
@@ -259,20 +279,30 @@ final class TreemapNSView: NSView, CALayerDelegate {
         overlayLayer.setNeedsDisplay()
     }
 
-    // Fallback (no-GPU) path only: CPU rasterisation of the big solid tiles at 2× retina
-    // is the resize bottleneck, so during a live drag we fill ¼ the pixels (1× backing)
-    // and re-render crisp when it ends. Metal renders full-res cheaply — it skips this.
+    // Metal path: synchronous presents (`presentsWithTransaction`) only while the
+    // window is actually being resized — they keep the drawable atomic with the
+    // bounds, but block the main thread until the GPU schedules, which is too
+    // expensive to pay on every ordinary frame (zoom animation at 120 Hz, scan
+    // ticks). Fallback (no-GPU) path: CPU rasterisation of the big solid tiles at
+    // 2× retina is the resize bottleneck, so during a live drag we fill ¼ the
+    // pixels (1× backing) and re-render crisp when it ends.
     override func viewWillStartLiveResize() {
         super.viewWillStartLiveResize()
-        guard renderer == nil else { return }
-        tileLayer.contentsScale = 1
-        overlayLayer.contentsScale = 1
+        if let metalLayer {
+            metalLayer.presentsWithTransaction = true
+        } else {
+            tileLayer.contentsScale = 1
+            overlayLayer.contentsScale = 1
+        }
     }
 
     override func viewDidEndLiveResize() {
         super.viewDidEndLiveResize()
-        guard renderer == nil else { return }
-        setScale(window?.backingScaleFactor ?? 2)
+        if let metalLayer {
+            metalLayer.presentsWithTransaction = false
+        } else {
+            setScale(window?.backingScaleFactor ?? 2)
+        }
     }
 
     // MARK: SwiftUI → view
@@ -282,6 +312,7 @@ final class TreemapNSView: NSView, CALayerDelegate {
                searchMatchIDs: Set<ObjectIdentifier>, highlightVersion: Int) {
         self.controller = controller
         let oldZoomRoot = self.zoomRoot   // capture before the assignment below (for zoom animation)
+        let oldMetric = self.metric
 
         let themeChanged = isDark != theme.isDark
         self.theme = theme
@@ -309,6 +340,12 @@ final class TreemapNSView: NSView, CALayerDelegate {
                renderer != nil, zoomLink == nil, !inLiveResize, !instances.isEmpty,
                startZoomAnimation(from: oldRoot, to: newRoot) {
                 overlayLayer.setNeedsDisplay()
+            } else if zoomLink != nil, zoomRoot === oldZoomRoot, metric == oldMetric, !themeChanged {
+                // Version-only bump (the 10 Hz scan tick, an FSEvents dirty-dot
+                // repaint) while the camera animates: defer the relayout to the
+                // end of the animation instead of cancelling it — otherwise the
+                // push-in can never complete during a live scan.
+                pendingRelayout = true
             } else {
                 if zoomLink != nil { cancelZoom() }
                 relayout()
@@ -348,11 +385,19 @@ final class TreemapNSView: NSView, CALayerDelegate {
         let changed = newSize != frame.size
         super.setFrameSize(newSize)
         guard changed else { return }
+        // A resize mid-zoom (split-divider drag — not a window live-resize) would
+        // render the old layout's camera over the new layout: fast-forward to the
+        // end state first, then lay out at the new size below.
+        if zoomLink != nil { finishZoom() }
         overlayLayer.frame = bounds
         if let metalLayer {
             // Backing-layer frame is managed by AppKit; we only resize the drawable + redraw.
             let scale = window?.backingScaleFactor ?? 2
             metalLayer.drawableSize = CGSize(width: bounds.width * scale, height: bounds.height * scale)
+            // This frame's present must stay atomic with the bounds change (no
+            // band behind a split-divider drag); reverted below unless a window
+            // live-resize keeps the synchronous path on.
+            metalLayer.presentsWithTransaction = true
         } else {
             tileLayer.frame = bounds
         }
@@ -362,11 +407,13 @@ final class TreemapNSView: NSView, CALayerDelegate {
         relayout()
         presentTiles()
         overlayLayer.setNeedsDisplay()
+        if let metalLayer, !inLiveResize { metalLayer.presentsWithTransaction = false }
     }
 
     // MARK: Layout (size-dependent placement + colours)
 
     private func relayout() {
+        pendingRelayout = false   // any relayout consumes a deferred one
         hovered = nil
         guard let controller, let zoomRoot, bounds.width > 1, bounds.height > 1 else {
             tiles = []; colors.removeAll(keepingCapacity: true); instances.removeAll(keepingCapacity: true)
@@ -647,11 +694,15 @@ final class TreemapNSView: NSView, CALayerDelegate {
 
     /// The topmost tile at `point` (a mouse location in view coordinates). Mouse
     /// coordinates arrive bottom-left; the tiles are stored top-left (matching the
-    /// layout), so flip Y before hit-testing. Named to avoid clashing with
-    /// `NSView.hitTest(_:)`.
+    /// layout), so flip Y before hit-testing. Sub-pixel tiles are skipped with the
+    /// same 0.5 pt threshold as the renderers — hover/click/menu must never land
+    /// on a tile the user can't see. Named to avoid clashing with `NSView.hitTest(_:)`.
     private func tileAt(_ point: CGPoint) -> TreemapTile? {
         let p = CGPoint(x: point.x, y: bounds.height - point.y)
-        for tile in tiles.reversed() where tile.rect.contains(p) { return tile }
+        for tile in tiles.reversed()
+        where tile.rect.width > 0.5 && tile.rect.height > 0.5 && tile.rect.contains(p) {
+            return tile
+        }
         return nil
     }
 
@@ -717,6 +768,9 @@ final class TreemapNSView: NSView, CALayerDelegate {
     private var zoomStart: CFTimeInterval = -1
     private var zoomViewport: CGRect?              // nil = full-bounds camera (no animation)
     private var zoomOnDone: (() -> Void)?
+    /// A version bump arrived mid-animation; the relayout it asked for runs when
+    /// the camera lands (consumed by `relayout()`).
+    private var pendingRelayout = false
     private static let zoomDuration: CFTimeInterval = 0.5
 
     /// Route a zoom navigation (from *any* entry point — treemap double-click, the left
@@ -799,6 +853,11 @@ final class TreemapNSView: NSView, CALayerDelegate {
         let done = zoomOnDone
         zoomOnDone = nil
         done?()                             // commit the zoom → apply → relayout → full-view present
+        if pendingRelayout {                // deferred scan-tick relayout (zoom-out path doesn't relayout)
+            relayout()
+            presentTiles()
+            overlayLayer.setNeedsDisplay()
+        }
     }
 
     /// Cancel a zoom without committing it (e.g. the view leaves its window mid-animation),

--- a/Tests/SpaceMattersTests/CleanupTests.swift
+++ b/Tests/SpaceMattersTests/CleanupTests.swift
@@ -72,6 +72,48 @@ import Foundation
         #expect(try FileManager.default.contentsOfDirectory(atPath: cache.path).isEmpty)
     }
 
+    /// A symlinked *intermediate* component (`~/.gradle` → an external volume)
+    /// passes the textual prefix check but resolves outside the fence — the
+    /// clean must refuse it, leaving the relocated cache untouched.
+    @Test func cleanRefusesSymlinkedIntermediateComponent() throws {
+        let fm = FileManager.default
+        let base = fm.temporaryDirectory.appendingPathComponent("sm-fence-\(UUID().uuidString)")
+        let home = base.appendingPathComponent("home")
+        let external = base.appendingPathComponent("external/gradle")
+        try fm.createDirectory(at: home, withIntermediateDirectories: true)
+        try fm.createDirectory(at: external.appendingPathComponent("caches"), withIntermediateDirectories: true)
+        try Data(count: 4096).write(to: external.appendingPathComponent("caches/keep.bin"))
+        // home/.gradle → external/gradle : the catalog path home/.gradle/caches
+        // starts with the fence but really lives outside it.
+        try fm.createSymbolicLink(at: home.appendingPathComponent(".gradle"), withDestinationURL: external)
+        defer { try? fm.removeItem(at: base) }
+
+        let target = home.appendingPathComponent(".gradle/caches").path
+        let result = CleanupEngine.clean(Self.cleanable([target]), allowedRoot: home.path)
+
+        #expect(result.refused == 1 && result.removed == 0)
+        #expect(fm.fileExists(atPath: external.appendingPathComponent("caches/keep.bin").path))
+    }
+
+    /// A `..` in the path also defeats the prefix check textually; the resolved
+    /// form escapes the fence and must be refused.
+    @Test func cleanRefusesDotDotEscape() throws {
+        let fm = FileManager.default
+        let base = fm.temporaryDirectory.appendingPathComponent("sm-dotdot-\(UUID().uuidString)")
+        let home = base.appendingPathComponent("home")
+        let outside = base.appendingPathComponent("outside")
+        try fm.createDirectory(at: home, withIntermediateDirectories: true)
+        try fm.createDirectory(at: outside, withIntermediateDirectories: true)
+        try Data(count: 4096).write(to: outside.appendingPathComponent("keep.bin"))
+        defer { try? fm.removeItem(at: base) }
+
+        let sneaky = home.path + "/../outside"
+        let result = CleanupEngine.clean(Self.cleanable([sneaky]), allowedRoot: home.path)
+
+        #expect(result.refused == 1 && result.removed == 0)
+        #expect(fm.fileExists(atPath: outside.appendingPathComponent("keep.bin").path))
+    }
+
     /// A symlink placed inside a cache must be removed as a link — its target,
     /// outside the cache, survives.
     @Test func cleanNeverFollowsSymlinks() throws {

--- a/Tests/SpaceMattersTests/EngineParsingTests.swift
+++ b/Tests/SpaceMattersTests/EngineParsingTests.swift
@@ -1,0 +1,119 @@
+import Testing
+import Foundation
+@testable import SpaceMatters
+
+/// Pins the pure parsing seams of the external-engine integrations — the values
+/// that decide whether a "Reclaim" button appears, what an image's layers say,
+/// and what a PVC's live usage is. None of these shell out.
+@Suite struct EngineParsingTests {
+
+    // MARK: Container sizes (docker human units → bytes)
+
+    @Test func parseHumanSizeHandlesDockerUnits() {
+        #expect(ContainerQueries.parseHumanSize("1.2GB") == 1_200_000_000)
+        #expect(ContainerQueries.parseHumanSize("512MB") == 512_000_000)
+        #expect(ContainerQueries.parseHumanSize("737kB") == 737_000)
+        #expect(ContainerQueries.parseHumanSize("2TB") == 2_000_000_000_000)
+        #expect(ContainerQueries.parseHumanSize("0B") == 0)
+        #expect(ContainerQueries.parseHumanSize(" 42B ") == 42)
+        #expect(ContainerQueries.parseHumanSize("n/a") == 0)
+        #expect(ContainerQueries.parseHumanSize("") == 0)
+    }
+
+    // MARK: `--format json` output (array vs JSONL)
+
+    @Test func parseJSONArrayAcceptsArrayAndJSONL() {
+        let array = ContainerQueries.parseJSONArray(#"[{"Id":"a"},{"Id":"b"}]"#)
+        #expect(array?.count == 2)
+        #expect(array?.first?["Id"] as? String == "a")
+
+        let jsonl = ContainerQueries.parseJSONArray("{\"Id\":\"a\"}\n{\"Id\":\"b\"}\n")
+        #expect(jsonl?.count == 2)
+        #expect(jsonl?.last?["Id"] as? String == "b")
+
+        #expect(ContainerQueries.parseJSONArray("not json at all") == nil)
+        #expect(ContainerQueries.parseJSONArray("") == nil)
+    }
+
+    // MARK: Layer build commands
+
+    @Test func cleanCommandStripsBuildNoise() {
+        #expect(ContainerQueries.cleanCommand("|3 A=1 B=2 /bin/sh -c npm ci") == "npm ci")
+        #expect(ContainerQueries.cleanCommand("#(nop) COPY . /app") == "COPY . /app")
+        #expect(ContainerQueries.cleanCommand("  RUN make  ") == "RUN make")
+    }
+
+    // MARK: kubelet stats summary → PVC usage
+
+    @Test func parseNodeUsageMapsPVCRefs() {
+        let raw = """
+        {"pods":[
+          {"volume":[
+            {"usedBytes":123456,"pvcRef":{"namespace":"db","name":"data-pg-0"}},
+            {"usedBytes":1,"name":"scratch-no-pvc"}
+          ]},
+          {"volume":[{"usedBytes":"789","pvcRef":{"namespace":"web","name":"cache"}}]}
+        ]}
+        """
+        let usage = K8sQueries.parseNodeUsage(raw)
+        #expect(usage["db/data-pg-0"] == 123_456)
+        #expect(usage["web/cache"] == 789)
+        #expect(usage.count == 2) // the pvcRef-less volume is ignored
+        #expect(K8sQueries.parseNodeUsage("{}").isEmpty)
+        #expect(K8sQueries.parseNodeUsage("garbage").isEmpty)
+    }
+
+    // MARK: Remote find quoting
+
+    @Test func shellQuoteNeutralizesSingleQuotes() {
+        #expect(RemoteFind.shellQuote("/plain/path") == "'/plain/path'")
+        // A quote in the path must not terminate the quoted string.
+        #expect(RemoteFind.shellQuote("/pa'th") == "'/pa'\\''th'")
+        let cmd = RemoteFind.command(rootPath: "/it's here")
+        #expect(cmd.contains("find '/it'\\''s here' -xdev"))
+    }
+
+    /// The host is user input: it must come after `--` so `-oProxyCommand=…`
+    /// can never be parsed as an ssh option.
+    @Test func sshHostFollowsEndOfOptions() {
+        let cmd = SSHTarget(user: "", host: "-oProxyCommand=touch /tmp/pwned", port: nil,
+                            path: "/", identityFile: nil).command()
+        let args = cmd.arguments
+        let dashIdx = try? #require(args.firstIndex(of: "--"))
+        let hostIdx = try? #require(args.firstIndex(of: "-oProxyCommand=touch /tmp/pwned"))
+        if let dashIdx, let hostIdx { #expect(dashIdx < hostIdx) }
+    }
+}
+
+/// Behavior of the hardened process plumbing: deadlines must hold even when
+/// the direct child spawns its own children or leaves a straggler on the pipe.
+@Suite struct ProcessRunnerTests {
+
+    @Test func nonexistentExecutableFailsCleanly() async {
+        let r = await ProcessRunner.run("/nonexistent/binary", [], timeout: 5)
+        #expect(!r.ok)
+        #expect(r.exitCode == -1)
+    }
+
+    /// The watchdog must take down the *grandchild* too — killing only the
+    /// direct `sh` would leave `sleep` holding the pipe (the old forever-hang).
+    @Test func watchdogKillsWholeProcessTree() async {
+        let start = Date()
+        let r = await ProcessRunner.run("/bin/sh", ["-c", "sh -c 'sleep 30'"], timeout: 1)
+        let elapsed = Date().timeIntervalSince(start)
+        #expect(r.timedOut)
+        #expect(elapsed < 10, "deadline must hold despite the grandchild (took \(elapsed)s)")
+    }
+
+    /// A backgrounded straggler that inherits the pipe and outlives the child
+    /// must only cost the bounded reader wait — never a hang.
+    @Test func exitedChildWithStragglerOnPipeReturnsPromptly() async {
+        let start = Date()
+        let r = await ProcessRunner.run("/bin/sh", ["-c", "echo done; sleep 30 & exit 0"], timeout: 20)
+        let elapsed = Date().timeIntervalSince(start)
+        #expect(r.exitCode == 0)
+        #expect(!r.timedOut)
+        #expect(elapsed < 10, "bounded reader wait must cap the straggler (took \(elapsed)s)")
+        #expect(r.stdoutString.contains("done")) // partial output survives
+    }
+}

--- a/Tests/SpaceMattersTests/NavigationTests.swift
+++ b/Tests/SpaceMattersTests/NavigationTests.swift
@@ -261,7 +261,14 @@ import Foundation
         await Self.waitForScan(c)
 
         let sibling = try #require(Self.child(c.root!, "sibling"))
-        let files = c.filesIn(sibling)
+        // File listings load off the main actor now: poll until it lands.
+        var files = c.filesIn(sibling)
+        let deadline = Date().addingTimeInterval(5)
+        while files.isEmpty && Date() < deadline {
+            await Task.yield()
+            RunLoop.main.run(until: Date().addingTimeInterval(0.02))
+            files = c.filesIn(sibling)
+        }
         let file = try #require(files.first)
         let rootPhysicalBefore = c.root!.aggPhysical.load(ordering: .relaxed)
 

--- a/Tests/SpaceMattersTests/StructuralIntegrityTests.swift
+++ b/Tests/SpaceMattersTests/StructuralIntegrityTests.swift
@@ -1,0 +1,113 @@
+import Testing
+import Foundation
+@testable import SpaceMatters
+
+/// Structural-integrity guarantees of the tree lifecycle: in-flight `remove`/
+/// `invalidate` must abort cleanly when the tree is replaced or torn down under
+/// them (epoch discipline), and a cancelled scan must be *drained* — no worker
+/// still mutating the tree — before it reports quiescence.
+@MainActor
+@Suite struct StructuralIntegrityTests {
+
+    /// Home pressed while a directory removal is suspended off-actor: the
+    /// removal must abort before touching the disk or the (gone) tree, and the
+    /// controller must land in a clean splash state.
+    @Test func goHomeDuringRemoveAbortsWithoutDeleting() async throws {
+        let root = try NavigationTests.makeFixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let c = ScanController()
+        c.scan(url: root)
+        await NavigationTests.waitForScan(c)
+
+        let a = try #require(NavigationTests.child(c.root!, "A"))
+        let aPath = root.appendingPathComponent("A").path
+
+        // Start the removal as a MainActor child task: it runs up to its first
+        // suspension (the off-actor extension walk), then Home tears the tree
+        // down before it can resume.
+        let removal = Task { await c.remove(directory: a, permanently: true) }
+        await Task.yield()
+        c.goHome()
+        let ok = await removal.value
+
+        #expect(!ok)
+        #expect(FileManager.default.fileExists(atPath: aPath), "the abort must happen before the disk removal")
+        #expect(c.root == nil)
+        #expect(c.phase == .idle)
+    }
+
+    /// Rescan pressed while an `invalidate` re-scans a subtree: the invalidate
+    /// must abort without corrupting the fresh scan's totals or File-types.
+    @Test func rescanDuringInvalidateLeavesFreshScanIntact() async throws {
+        let root = try NavigationTests.makeFixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let c = ScanController()
+        c.scan(url: root)
+        await NavigationTests.waitForScan(c)
+        let cleanPhysical = c.totalPhysical
+        let cleanDirs = c.dirCount
+
+        let sub = try #require(NavigationTests.child(c.root!, "A"))
+        let invalidation = Task { await c.invalidate(subtree: sub) }
+        await Task.yield()
+        c.rescan()
+        let ok = await invalidation.value
+        #expect(!ok)
+
+        await NavigationTests.waitForScan(c)
+        #expect(c.phase == .finished)
+        // The fresh scan's numbers match the undisturbed first scan exactly —
+        // no leftover subtraction from the aborted invalidate.
+        #expect(c.totalPhysical == cleanPhysical)
+        #expect(c.dirCount == cleanDirs)
+    }
+
+    /// While one structural operation is in flight, a second one is refused —
+    /// two concurrent tree surgeries would subtract aggregates from each other.
+    @Test func concurrentStructuralOpsAreExclusive() async throws {
+        let root = try NavigationTests.makeFixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let c = ScanController()
+        c.scan(url: root)
+        await NavigationTests.waitForScan(c)
+
+        let a = try #require(NavigationTests.child(c.root!, "A"))
+        let sibling = try #require(NavigationTests.child(c.root!, "sibling"))
+
+        let first = Task { await c.remove(directory: a, permanently: true) }
+        await Task.yield() // let it pass its guards and suspend
+        let second = await c.remove(directory: sibling, permanently: true)
+        #expect(!second, "second structural op must be refused while the first is in flight")
+        let firstOK = await first.value
+        #expect(firstOK)
+        // The refused sibling is untouched, on disk and in the tree.
+        #expect(FileManager.default.fileExists(atPath: root.appendingPathComponent("sibling").path))
+        #expect(NavigationTests.child(c.root!, "sibling") != nil)
+    }
+
+    /// A cancelled scan reports drained only once every worker has exited; after
+    /// that, the tree must be quiescent (no late aggregate writes).
+    @Test func cancelDrainsWorkersBeforeQuiescence() async throws {
+        // A wide fixture so several workers are actually busy when cancel lands.
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent("mds-drain-\(UUID().uuidString)")
+        for i in 0..<80 {
+            let dir = root.appendingPathComponent("d\(i)/e\(i)")
+            try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+            try Data(count: 4096).write(to: dir.appendingPathComponent("f.bin"))
+        }
+        defer { try? fm.removeItem(at: root) }
+
+        let node = FSNode(name: "root", parent: nil)
+        let scanner = DirectoryScanner(root: node, rootPath: root.path)
+        scanner.start()
+        scanner.cancel()
+        await Task.detached { scanner.waitUntilFinished() }.value
+
+        #expect(scanner.isDrained)
+        let settled = node.aggPhysical.load(ordering: .relaxed)
+        try await Task.sleep(for: .milliseconds(80))
+        #expect(node.aggPhysical.load(ordering: .relaxed) == settled,
+                "no worker may keep writing after waitUntilFinished returns")
+    }
+}

--- a/bundle.sh
+++ b/bundle.sh
@@ -30,6 +30,11 @@ fi
 VERSION="${VERSION:-$( { git describe --tags --abbrev=0 2>/dev/null || true; } | sed 's/^v//')}"
 [ -z "$VERSION" ] && VERSION="0.1.0"
 BUILD="${BUILD:-$(git rev-list --count HEAD 2>/dev/null || echo 1)}"
+# Interpolated into the Info.plist heredoc below: keep them plist-safe so a
+# hostile tag name can't inject XML.
+VERSION="$(printf '%s' "$VERSION" | tr -cd '0-9A-Za-z.-')"
+BUILD="$(printf '%s' "$BUILD" | tr -cd '0-9')"
+[ -z "$BUILD" ] && BUILD=1
 
 cat > "$APP/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Context

A full source audit of `main` @ a0bd856 (4 parallel review passes over scanner/model, ViewModels, rendering, security/CI, every finding verified against the code) surfaced **1 critical, 12 major and 17 minor findings**, concentrated on three root causes: reentrancy of structural tree operations, external-process lifecycle, and exact mode vs post-scan operations. This PR remediates all of them in 6 thematic commits. The full report (with per-finding remediation status) lives in `docs/audit/AUDIT-2026-07-12.md`, local by design (`docs/audit/` is gitignored).

## The critical one (C1)

`remove()` / `invalidate()` captured an `FSNode`, suspended (extension walk, trash I/O, subtree re-scan), and never revalidated: a **Rescan or Home during the suspension** freed the ancestor chain → `unowned` trap on resume (or silently corrupted the replacement scan's stats). A realistic repro was "Move to Trash on a big node_modules → click Rescan while it runs".

**Fix, one mechanism for the whole family:** a monotonic `treeEpoch` (bumped by `startBackend`/`goHome`) re-checked after every `await`, strong `retainedAncestors` held across suspensions, structural-op mutual exclusion, a *draining* cancel (`DirectoryScanner` now tracks live workers, and `waitUntilFinished()` only returns once the tree is quiescent), and the outgoing tree retained until its workers exit, then released off-main.

## Commits

| Commit | Scope |
|---|---|
| `1a69f0c` fix(core) | C1 plus M1 (op exclusivity), M2 (drained cancel) and M9 (layoutCache purge), pinned by 4 new `StructuralIntegrityTests` |
| `b1f9d3a` fix(process) | M4 (terminate on never-launched Process crash), M5 (`ProcessTree` kills descendants via `proc_listpids`, so a wrapper's `ssh` grandchild can no longer hold pipes open forever), M6 (container actions: 10 min deadline plus failures surfaced in UI), M7 (`rmi` no longer forced, so it cannot tear down running containers), M10 (`loadID` guard) |
| `c72d3ef` fix(safety) | M3 (FSEvents context retain/release, a use-after-free), M8 (hardlink dedup keyed `(devid, fileID)`, since bare inodes collide across volumes and firmlinks), M11 (cleanup fence canonicalized: symlinked intermediate components and `..` refused, counter-example tests) |
| `1609f62` perf(render) | M12 (zoom animation survives scan ticks via deferred relayout instead of cancel) plus resize-mid-zoom fast-forward, async presents outside resize, grow-only Intel attachments, 0.5 pt hit-test cull, O(1) table selection sync, cached sorted file listings, hover isolated from the SwiftUI body |
| `d8505cc` fix(polish) | search rebind after invalidate, real CLI exit codes, `filesIn()` off the main actor, CleanupController guards, `ExtStat.subtract` clamp, per-volume trash attribution, remote-stream overflow rejection, `--` before ssh host, plist sanitization |
| `0debea4` test | engine parsers (`parseHumanSize`, JSONL, `cleanCommand`, `parseNodeUsage`), `shellQuote`, ProcessRunner watchdog, kill-tree and straggler coverage, where the straggler test exposed and fixed a total output loss on that path |

## Verification

- `swift test`: **48 tests green** (33 pre-existing plus 15 new), build clean.
- Headless scan matches `du -skx` byte-exact. CLI exit codes exercised for usage, error and success.
- App launched from the branch build: splash, scan, Metal rendering OK.
- Known limitation: no automated pixel-level GUI validation (TCC), so **two things are worth a human eye**: the zoom animation *during* a live scan (must complete instead of snapping), and a prune or remove against a real Podman (error surfacing).

## Accepted trade-offs (documented in code)

- Cleanup TOCTOU (lstat→removeItem): same-user boundary only. An attacker running as the user can delete anything directly, and the fence targets catalog bugs and relocated caches.
- Exact-mode post-scan reconciliation stays best-effort (negatives clamped, and the complete fix would require sharing the scanner's dedup state with the reconciliation walks).
- The Intel/eGPU texture path (grow-only plus `renderTargetWidth` clamp) is untested on real non-memoryless hardware (the local machine is Apple Silicon).
