### PR TITLE
Persistent world treemap: camera navigation, hierarchical LOD and morphs (SPEC-10)

### DIFF
--- a/Sources/SpaceMatters/ViewModel/ScanController.swift
+++ b/Sources/SpaceMatters/ViewModel/ScanController.swift
@@ -43,8 +43,14 @@ final class ScanController {
 
     /// The node currently focused in the treemap / selected in the list.
     var selection: FSNode?
-    /// The directory the treemap is zoomed into (defaults to root).
+    /// The directory the treemap is focused on (defaults to root). SPEC-10: this
+    /// is a *derived* value while the camera roams (`cameraDidFocus`), and an
+    /// explicit request when navigation asks for it (`zoomRequestID` bumps).
     var zoomRoot: FSNode?
+    /// Bumped by every explicit navigation (double-click, outline, breadcrumb,
+    /// ⌘↑…) — the treemap answers with an animated camera fit. Camera-derived
+    /// focus updates change `zoomRoot` without bumping this.
+    private(set) var zoomRequestID: Int = 0
 
     /// Which directories are expanded in the outline (central, so the treemap can
     /// programmatically expand ancestors to reveal a selection).
@@ -1151,7 +1157,15 @@ final class ScanController {
         guard node.isDirectory else { return }
         zoomRoot = node
         setSelection(node)
-        bump()
+        zoomRequestID &+= 1
+    }
+
+    /// SPEC-10: the treemap camera settled over `node` — follow it in the
+    /// breadcrumb/list without triggering a camera flight back (no request bump)
+    /// and without hijacking the selection.
+    func cameraDidFocus(_ node: FSNode) {
+        guard node !== zoomRoot else { return }
+        zoomRoot = node
     }
 
     /// Breadcrumb path: scan root → current zoom root.
@@ -1168,7 +1182,7 @@ final class ScanController {
     func navigate(to node: FSNode) {
         zoomRoot = node
         reveal(node) // sets selection, selectedRowID, revealTarget, expands ancestors
-        bump()
+        zoomRequestID &+= 1
     }
 
     func zoomOut() {
@@ -1176,14 +1190,14 @@ final class ScanController {
             zoomRoot = parent
             setSelection(parent)
             revealTarget = parent // scroll the list to the newly focused node
-            bump()
+            zoomRequestID &+= 1
         }
     }
 
     func resetZoom() {
         zoomRoot = root
         setSelection(root)
-        bump()
+        zoomRequestID &+= 1
     }
 
     /// Whether zooming out is possible (drives the breadcrumb button + ⌘↑).

--- a/Sources/SpaceMatters/Views/TreemapLayout.swift
+++ b/Sources/SpaceMatters/Views/TreemapLayout.swift
@@ -115,7 +115,10 @@ enum TreemapLayout {
         return result
     }
 
-    fileprivate struct Item {
+    /// One child slot of a node's layout: a sub-directory, the node's own-files
+    /// block, or (SPEC-05 / file LOD) an individual file. Shared with
+    /// `TreemapWorld`, which reuses the same decision/geometry passes.
+    struct Item {
         let weight: Double
         let node: FSNode
         let isFileBlock: Bool
@@ -197,7 +200,8 @@ enum TreemapLayout {
 
     /// Build a node's size-independent items, sorted by weight (descending) so the
     /// squarify decisions and placement can run without re-sorting on every frame.
-    private static func buildItems(
+    /// Internal: `TreemapWorld` builds its per-node entries from the same items.
+    static func buildItems(
         node: FSNode, depth: Int, metric: SizeMetric, files: [FileTileInfo]?
     ) -> (items: [Item], weights: [Double]) {
         var items: [Item] = []

--- a/Sources/SpaceMatters/Views/TreemapMetalRenderer.swift
+++ b/Sources/SpaceMatters/Views/TreemapMetalRenderer.swift
@@ -2,11 +2,16 @@ import Metal
 import QuartzCore
 import simd
 
-// GPU renderer for the treemap tiles (SPEC-09). The engine is 3D-native from the
-// start — instanced 3D quads, an MVP camera and a depth buffer — but the current
-// view is its *orthographic top-down projection*: flat tiles (height 0) seen from
-// straight above, the classic 2D treemap. Going 3D later is a camera + height
-// change, not a rewrite (SPEC-09 §9).
+// GPU renderer for the treemap tiles (SPEC-09, extended by SPEC-10). The engine is
+// 3D-native from the start — instanced 3D quads, an MVP camera and a depth buffer —
+// but the current view is its *orthographic top-down projection*: flat tiles
+// (height 0) seen from straight above, the classic 2D treemap. Going 3D later is a
+// camera + height change, not a rewrite (SPEC-09 §9).
+//
+// SPEC-10 additions: a camera-only draw path that re-uses the last uploaded
+// instances (a pan/zoom/resize frame writes no buffer at all), and a second
+// per-instance buffer + `morph` uniform so every re-bake of the world is an
+// animated interpolation instead of a teleport.
 //
 // Only the tile *fill* is the GPU's job; layout, colour source, hit-testing and the
 // selection/hover overlay live in `TreemapNSView`. One `drawPrimitives(instanceCount:)`
@@ -32,12 +37,12 @@ struct Camera {
 
     /// Orthographic top-down mapping the world rect `viewport` (points, top-left) exactly
     /// onto the drawable: worldX vx→vx+vw to NDC −1→+1, worldZ vy→vy+vh (top→bottom) to
-    /// NDC +1→−1. The full-view camera passes the whole bounds; an animated zoom passes a
-    /// shrinking/growing sub-rect so the map pushes toward (or pulls back from) a folder.
+    /// NDC +1→−1. The full-view camera passes the whole bounds; a moving camera (pan,
+    /// zoom, animated fit) passes any sub-rect — same instances, different matrix.
     /// Ortho of flat tiles preserves proportions, so the map reads as plain 2D.
     /// z is a constant mid-depth; the Y column stays 0 until boxes extrude.
     static func ortho(viewport v: CGRect) -> Camera {
-        let vw = max(Double(v.width), 1), vh = max(Double(v.height), 1)
+        let vw = max(Double(v.width), .leastNormalMagnitude), vh = max(Double(v.height), .leastNormalMagnitude)
         let vx = Double(v.minX), vy = Double(v.minY)
         let col0 = SIMD4<Float>(Float(2 / vw), 0, 0, 0)                 // X → clip.x
         let col1 = SIMD4<Float>(0, 0, 0, 0)                            // Y (height) → nothing yet
@@ -48,10 +53,15 @@ struct Camera {
     }
 }
 
-/// Uniforms shared by both shader stages. Matches the MSL `Uniforms` (80 bytes).
+/// Uniforms shared by both shader stages. Matches the MSL `Uniforms` (96 bytes).
 private struct Uniforms {
     var viewProj: simd_float4x4
     var borderColor: SIMD4<Float>
+    /// x = morph progress t (0 → previous instances, 1 → current).
+    /// y/z = screen points per world unit (camera scale, per axis) — converts tile
+    /// extents to on-screen points for the cushion/border thresholds, so borders
+    /// keep a constant screen width at any zoom. w reserved.
+    var morph: SIMD4<Float>
 }
 
 final class TreemapMetalRenderer {
@@ -61,11 +71,18 @@ final class TreemapMetalRenderer {
     private let depthState: MTLDepthStencilState
 
     // Triple-buffered instance storage: the CPU never rewrites a buffer the GPU is
-    // still reading. Each slot's buffer is grown (never shrunk) to fit the tile count.
+    // still reading. Slots rotate ONLY when new data is uploaded — camera-only
+    // frames rebind the last slot untouched. The queue completes in order, so by
+    // the time a slot comes around again (two uploads later, ≥1 semaphore wait),
+    // every draw that referenced it has completed.
     private static let maxInflight = 3
     private let inflight = DispatchSemaphore(value: maxInflight)
     private var instanceBuffers: [MTLBuffer?]
-    private var frameIndex = 0
+    private var prevBuffers: [MTLBuffer?]
+    private var slot = 0
+    private var boundInstances: MTLBuffer?
+    private var boundPrev: MTLBuffer?
+    private var instanceCount = 0
 
     private let transientStorage: MTLStorageMode
     private var depthTexture: MTLTexture?
@@ -106,27 +123,59 @@ final class TreemapMetalRenderer {
         self.depthState = depthState
         self.transientStorage = transient
         self.instanceBuffers = Array(repeating: nil, count: Self.maxInflight)
+        self.prevBuffers = Array(repeating: nil, count: Self.maxInflight)
     }
 
-    /// Draw `instances` into `layer` (clearing to `clearColor`). Safe to call with an
-    /// empty array — it just clears, so an empty tree shows the background.
-    func render(into layer: CAMetalLayer, instances: [TileInstance], camera: Camera,
-                clearColor: SIMD4<Float>, borderColor: SIMD4<Float>) {
+    /// Upload a new tile set (rotating the buffer slot). `previous` must be index-
+    /// aligned with `instances` (the morph pairing); pass `nil` when there is
+    /// nothing to morph from — draws then run with t = 1 against the same buffer.
+    /// Upload happens under the same in-flight discipline as draws (see `draw`).
+    func upload(instances: [TileInstance], previous: [TileInstance]?) {
+        slot = (slot + 1) % Self.maxInflight
+        instanceCount = instances.count
+        boundInstances = instances.isEmpty ? nil : copy(instances, into: &instanceBuffers[slot], slot: slot)
+        if let previous, previous.count == instances.count, !previous.isEmpty {
+            boundPrev = copy(previous, into: &prevBuffers[slot], slot: slot)
+        } else {
+            boundPrev = nil
+        }
+    }
+
+    private func copy(_ data: [TileInstance], into store: inout MTLBuffer?, slot: Int) -> MTLBuffer? {
+        let needed = data.count * MemoryLayout<TileInstance>.stride
+        if store == nil || store!.length < needed {
+            // Grow with headroom so a slowly-growing tile count doesn't reallocate every frame.
+            store = device.makeBuffer(length: max(needed, 4096), options: .storageModeShared)
+        }
+        guard let buffer = store else { return nil }
+        data.withUnsafeBytes { raw in
+            buffer.contents().copyMemory(from: raw.baseAddress!, byteCount: raw.count)
+        }
+        return buffer
+    }
+
+    /// Draw the last uploaded instances into `layer`. A camera-only frame calls this
+    /// alone — no buffer writes, just a new matrix (and morph progress). `contentSize`
+    /// is the displayed pixel size; when the drawable is pooled larger than the view
+    /// (SPEC-10 §3.6) the viewport clamps rendering to the visible region.
+    func draw(into layer: CAMetalLayer,
+              camera: Camera,
+              pointsPerUnit: (sx: CGFloat, sy: CGFloat) = (1, 1),
+              morph: Float = 1,
+              clearColor: SIMD4<Float>,
+              borderColor: SIMD4<Float>,
+              contentSize: CGSize? = nil) {
         let size = layer.drawableSize
         guard size.width > 0, size.height > 0 else { return }
         ensureAttachments(size)
         guard let drawable = layer.nextDrawable() else { return }
 
         inflight.wait()
-        frameIndex = (frameIndex + 1) % Self.maxInflight
-        let buffer = instances.isEmpty ? nil : ensureInstanceBuffer(slot: frameIndex, count: instances.count)
-        if let buffer {
-            instances.withUnsafeBytes { raw in
-                buffer.contents().copyMemory(from: raw.baseAddress!, byteCount: raw.count)
-            }
-        }
 
-        var uniforms = Uniforms(viewProj: camera.viewProjection, borderColor: borderColor)
+        var uniforms = Uniforms(viewProj: camera.viewProjection,
+                                borderColor: borderColor,
+                                morph: SIMD4<Float>(boundPrev == nil ? 1 : morph,
+                                                    Float(pointsPerUnit.sx), Float(pointsPerUnit.sy), 0))
 
         let rpd = MTLRenderPassDescriptor()
         rpd.colorAttachments[0].texture = drawable.texture
@@ -148,15 +197,22 @@ final class TreemapMetalRenderer {
             inflight.signal()
             return
         }
-        if let buffer {
+        if let buffer = boundInstances, instanceCount > 0 {
             enc.setRenderPipelineState(pipeline)
             enc.setDepthStencilState(depthState)
+            // Pooled drawable: draw only into the displayed region; contentsRect crops.
+            let content = contentSize ?? size
+            enc.setViewport(MTLViewport(originX: 0, originY: 0,
+                                        width: Double(min(content.width, size.width)),
+                                        height: Double(min(content.height, size.height)),
+                                        znear: 0, zfar: 1))
             enc.setVertexBuffer(buffer, offset: 0, index: 0)
             enc.setVertexBytes(&uniforms, length: MemoryLayout<Uniforms>.stride, index: 1)
+            enc.setVertexBuffer(boundPrev ?? buffer, offset: 0, index: 2)
             enc.setFragmentBytes(&uniforms, length: MemoryLayout<Uniforms>.stride, index: 1)
             // 4-vertex triangle strip (a unit quad), one instance per tile.
             enc.drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: 4,
-                               instanceCount: instances.count)
+                               instanceCount: instanceCount)
         }
         enc.endEncoding()
         cmd.addCompletedHandler { [inflight] _ in inflight.signal() }
@@ -172,15 +228,6 @@ final class TreemapMetalRenderer {
             cmd.present(drawable)
             cmd.commit()
         }
-    }
-
-    private func ensureInstanceBuffer(slot: Int, count: Int) -> MTLBuffer? {
-        let needed = count * MemoryLayout<TileInstance>.stride
-        if let buf = instanceBuffers[slot], buf.length >= needed { return buf }
-        // Grow with headroom so a slowly-growing tile count doesn't reallocate every frame.
-        let buf = device.makeBuffer(length: max(needed, 4096), options: .storageModeShared)
-        instanceBuffers[slot] = buf
-        return buf
     }
 
     private func ensureAttachments(_ size: CGSize) {
@@ -222,6 +269,7 @@ final class TreemapMetalRenderer {
     struct Uniforms {
         float4x4 viewProj;
         float4   borderColor;
+        float4   morph;      // x = t (0 = previous, 1 = current), yz = points per world unit
     };
     struct VOut {
         float4 pos [[position]];
@@ -231,22 +279,31 @@ final class TreemapMetalRenderer {
         float4 color;
     };
 
-    // A unit quad from the vertex id (triangle strip 0..3), placed by the instance and
-    // projected by the camera. Today height = 0 → a flat quad on the ground plane.
+    // A unit quad from the vertex id (triangle strip 0..3), placed by the instance
+    // (morph-interpolated between the previous and current sets) and projected by
+    // the camera. Today height = 0 → a flat quad on the ground plane.
     vertex VOut treemapVertex(uint vid [[vertex_id]],
                               uint iid [[instance_id]],
                               const device TileInstance* inst [[buffer(0)]],
-                              constant Uniforms& u [[buffer(1)]]) {
+                              constant Uniforms& u [[buffer(1)]],
+                              const device TileInstance* prev [[buffer(2)]]) {
         float fu = float(vid & 1);
         float fv = float((vid >> 1) & 1);
-        TileInstance t = inst[iid];
-        float3 world = float3(t.origin.x + fu * t.size.x, 0.0, t.origin.z + fv * t.size.z);
+        float t = u.morph.x;
+        TileInstance a = prev[iid];
+        TileInstance b = inst[iid];
+        float4 origin = mix(a.origin, b.origin, t);
+        float4 size   = mix(a.size,   b.size,   t);
+        float4 color  = mix(a.color,  b.color,  t);
+        float3 world = float3(origin.x + fu * size.x, 0.0, origin.z + fv * size.z);
         VOut o;
         o.pos = u.viewProj * float4(world, 1.0);
         o.uv = float2(fu, fv);
-        o.tileSize = float2(t.size.x, t.size.z);
-        o.dim = t.size.w;
-        o.color = t.color;
+        // Screen-point extents: world units × camera scale — the cushion/border
+        // thresholds stay in points, so their look is zoom-invariant.
+        o.tileSize = float2(size.x * u.morph.y, size.z * u.morph.z);
+        o.dim = size.w;
+        o.color = color;
         return o;
     }
 

--- a/Sources/SpaceMatters/Views/TreemapView.swift
+++ b/Sources/SpaceMatters/Views/TreemapView.swift
@@ -5,9 +5,15 @@ import QuartzCore
 
 /// Treemap view. The map itself is drawn by a plain AppKit `NSView`
 /// (`TreemapNSView`) rather than a SwiftUI `Canvas`, so a window resize is driven
-/// straight by AppKit — `setFrameSize` → recompute rects → redraw — with **no**
+/// straight by AppKit — `setFrameSize` → camera update → redraw — with **no**
 /// SwiftUI recompute / reconcile / display-list trip per frame. Profiling showed
 /// that per-frame SwiftUI machinery, not the drawing, was the resize bottleneck.
+///
+/// SPEC-10: the tiles live in a persistent *world* (`TreemapWorld`) and the view
+/// looks at it through a camera. Resize, pan and zoom are camera moves (no
+/// relayout); navigation is map-like (scroll to pan, pinch/wheel to zoom, double
+/// click to dive); detail follows the camera (projected-size LOD); and every
+/// structural change of the world is morph-animated instead of teleporting.
 ///
 /// This thin SwiftUI wrapper only: (1) reads the controller's observable inputs so
 /// SwiftUI calls `updateNSView` when they change, (2) hosts the hover-label overlay
@@ -38,6 +44,7 @@ struct TreemapView: View {
                 theme: theme,
                 version: controller.version,
                 zoomRoot: controller.zoomRoot,
+                zoomRequestID: controller.zoomRequestID,
                 metric: controller.metric,
                 selection: controller.selection,
                 selectedExt: controller.selectedExt,
@@ -121,14 +128,15 @@ private struct HoverPill: View {
 }
 
 /// Bridges the AppKit `TreemapNSView` into SwiftUI. `updateNSView` pushes the
-/// current observable inputs; the NSView decides what that implies (relayout vs a
-/// cheap overlay/dimming redraw).
+/// current observable inputs; the NSView decides what that implies (world sync,
+/// camera navigation, or a cheap overlay/dimming redraw).
 private struct TreemapRepresentable: NSViewRepresentable {
     let renderer: TreemapMetalRenderer
     let controller: ScanController
     let theme: Theme
     let version: UInt64
     let zoomRoot: FSNode?
+    let zoomRequestID: Int
     let metric: SizeMetric
     let selection: FSNode?
     let selectedExt: ExtKey?
@@ -141,29 +149,29 @@ private struct TreemapRepresentable: NSViewRepresentable {
         let view = TreemapNSView(renderer: renderer)
         view.onHover = onHover
         view.apply(controller: controller, theme: theme, version: version, zoomRoot: zoomRoot,
-                   metric: metric, selection: selection, selectedExt: selectedExt,
-                   searchMatchIDs: searchMatchIDs, highlightVersion: highlightVersion)
+                   zoomRequestID: zoomRequestID, metric: metric, selection: selection,
+                   selectedExt: selectedExt, searchMatchIDs: searchMatchIDs,
+                   highlightVersion: highlightVersion)
         return view
     }
 
     func updateNSView(_ view: TreemapNSView, context: Context) {
         view.onHover = onHover
         view.apply(controller: controller, theme: theme, version: version, zoomRoot: zoomRoot,
-                   metric: metric, selection: selection, selectedExt: selectedExt,
-                   searchMatchIDs: searchMatchIDs, highlightVersion: highlightVersion)
+                   zoomRequestID: zoomRequestID, metric: metric, selection: selection,
+                   selectedExt: selectedExt, searchMatchIDs: searchMatchIDs,
+                   highlightVersion: highlightVersion)
     }
 }
 
-/// The drawn treemap: an AppKit view AppKit resizes directly. Tiles are rendered by
-/// the GPU into the view's backing `CAMetalLayer` (SPEC-09); the hover outline +
-/// selection spotlight live in a CG overlay layer (redrawn on hover/selection
-/// alone), so hovering never re-renders the ~thousands of tiles.
-///
-/// Allocation discipline (the resize hot path is `setFrameSize` → `relayout` →
-/// `presentTiles`): tile colours (a bounded LUT), the hue-index cache and theme
-/// CGColors are all reused across frames; the per-frame `instances`/`sizeScratch`
-/// buffers keep their capacity. Only the tiles array (whose rects genuinely change
-/// every frame) is rebuilt.
+/// The drawn treemap: an AppKit view AppKit resizes directly. Tiles live in the
+/// persistent `TreemapWorld` and are rendered by the GPU into the view's backing
+/// `CAMetalLayer` through a camera; the hover outline + selection spotlight live
+/// in a CG overlay layer that follows the camera. A camera move (resize, pan,
+/// zoom) re-renders with a new matrix — no layout, no instance packing, no
+/// allocation. The draw list rebuilds only when the camera leaves the built
+/// margin, crosses an LOD threshold, or the data changes — and structural
+/// changes morph instead of jumping.
 final class TreemapNSView: NSView, CALayerDelegate {
     var onHover: ((HoverInfo?) -> Void)?
 
@@ -172,6 +180,7 @@ final class TreemapNSView: NSView, CALayerDelegate {
     private var theme = Theme(isDark: true)
     private var version: UInt64 = .max
     private var zoomRoot: FSNode?
+    private var zoomRequestID: Int = .min
     private var metric: SizeMetric = .physical
     private var selection: FSNode?
     private var selectedExt: ExtKey?
@@ -179,20 +188,50 @@ final class TreemapNSView: NSView, CALayerDelegate {
     private var highlightVersion: Int = .min
     private var isDark = true
 
-    // Layout state.
-    private var tiles: [TreemapTile] = []
-    private var instances: [TileInstance] = []    // GPU instances (culled to visible tiles)
+    // The world and the camera (SPEC-10).
+    private let world = TreemapWorld()
+    private var camera = WorldCamera(rect: .zero)
+    /// Camera glued to the world bounds: a resize re-fits instead of preserving scale.
+    private var fitMode = true
+    private var scanRoot: FSNode?
+
+    // Draw list (world coordinates) & GPU instances (camera-rebased floats).
+    private var tiles: [TreemapWorld.Tile] = []
     private var regions: [ObjectIdentifier: CGRect] = [:]
     private var regionsBuilt = false
-    private var hovered: TreemapTile?
+    private var instances: [TileInstance] = []
+    private var rebaseOrigin = CGPoint.zero
+    /// World rect the current build covers (visible + margin) and its scale — the
+    /// camera can roam inside without a rebuild.
+    private var builtRect = CGRect.zero
+    private var builtScale: (sx: CGFloat, sy: CGFloat) = (1, 1)
+    /// World rects of the previous build, keyed by tile identity — morph pairing.
+    private var lastRects: [TreemapWorld.TileKey: CGRect] = [:]
+    private var hovered: TreemapWorld.Tile?
 
-    // Tile layer: the view's backing `CAMetalLayer` (SPEC-09). The selection/hover
-    // overlay stays a CG layer above it (Phase 1).
+    // Morph clock (structural transitions) + camera animation (navigation fits).
+    private var animLink: CADisplayLink?
+    private var morphStart: CFTimeInterval = -1
+    private var morphT: Float = 1
+    private static let morphDuration: CFTimeInterval = 0.22
+    private var camFrom = CGRect.zero
+    private var camTo = CGRect.zero
+    private var camStart: CFTimeInterval = -1
+    private var camAnimating = false
+    private static let camDuration: CFTimeInterval = 0.5
+
+    /// Debounced camera-settle work: derive the focused folder for the breadcrumb.
+    private var focusWork: DispatchWorkItem?
+    /// One-shot follow-up when a file listing was still loading during a build.
+    private var fileRetryScheduled = false
+    private var fileAttempts: [ObjectIdentifier: Int] = [:]
+
+    // Layers.
     private let metalLayer: CAMetalLayer
     private let renderer: TreemapMetalRenderer
     private let overlayLayer = CALayer()
 
-    // MARK: Caches (persist across relayouts)
+    // MARK: Caches (persist across rebuilds)
 
     private static let brightnessBuckets = 256
     private let paletteCount = Theme.paletteHues.count
@@ -200,9 +239,6 @@ final class TreemapNSView: NSView, CALayerDelegate {
     private var colorLUT: [SIMD4<Float>?] = []
     private var colorKey: ColorKey?
     private var sizeScratch: [Int64] = []
-
-    private var rootFilesCache: [FileTileInfo]?
-    private var rootFilesKey: RootFilesKey?
 
     // Theme-derived CGColors for the overlay (rebuilt on theme change).
     private var backgroundCG = CGColor(gray: 0, alpha: 1)
@@ -216,6 +252,11 @@ final class TreemapNSView: NSView, CALayerDelegate {
     private static let hoverCG = CGColor(gray: 1, alpha: 0.95)
 
     private struct ColorKey: Equatable { let isDark: Bool; let version: UInt64 }
+
+    /// Aspect drift (window vs world) beyond which the end of a live resize
+    /// re-bakes the world at the new aspect (animated). Below it, the bounded
+    /// stretch is kept — decisions stay put.
+    private static let aspectHysteresis: CGFloat = 0.10
 
     // MARK: Setup
 
@@ -269,15 +310,42 @@ final class TreemapNSView: NSView, CALayerDelegate {
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
-        if window == nil { cancelZoom() }     // break the CADisplayLink → self cycle on teardown
+        if window == nil { cancelAnimations() }   // break the CADisplayLink → self cycle on teardown
     }
 
     private func setScale(_ scale: CGFloat) {
         metalLayer.contentsScale = scale
-        metalLayer.drawableSize = CGSize(width: bounds.width * scale, height: bounds.height * scale)
+        updateDrawableSize(pooled: false)
         presentTiles()
         overlayLayer.contentsScale = scale
         overlayLayer.setNeedsDisplay()
+    }
+
+    /// Size the drawable. During a live resize the drawable is *pooled*: rounded up
+    /// to 256-px steps and cropped via `contentsRect`, so the CAMetalLayer's
+    /// IOSurface pool survives the drag instead of reallocating per frame
+    /// (SPEC-10 §3.6 — the profiled hitch source). At rest the size is exact.
+    private func updateDrawableSize(pooled: Bool) {
+        let scale = metalLayer.contentsScale
+        let target = CGSize(width: max(bounds.width * scale, 1), height: max(bounds.height * scale, 1))
+        if pooled {
+            let pw = (Int(target.width) + 255) & ~255
+            let ph = (Int(target.height) + 255) & ~255
+            let current = metalLayer.drawableSize
+            let w = max(CGFloat(pw), current.width)
+            let h = max(CGFloat(ph), current.height)
+            metalLayer.drawableSize = CGSize(width: w, height: h)
+            metalLayer.contentsRect = CGRect(x: 0, y: 0, width: target.width / w, height: target.height / h)
+        } else {
+            metalLayer.drawableSize = target
+            metalLayer.contentsRect = CGRect(x: 0, y: 0, width: 1, height: 1)
+        }
+    }
+
+    /// Pixel size actually displayed (≤ drawableSize when pooled).
+    private var contentPixelSize: CGSize {
+        let scale = metalLayer.contentsScale
+        return CGSize(width: bounds.width * scale, height: bounds.height * scale)
     }
 
     // Synchronous presents (`presentsWithTransaction`) only while the window is
@@ -292,61 +360,106 @@ final class TreemapNSView: NSView, CALayerDelegate {
     override func viewDidEndLiveResize() {
         super.viewDidEndLiveResize()
         metalLayer.presentsWithTransaction = false
+        updateDrawableSize(pooled: false)
+        // Aspect hysteresis: a drag that left the window/world aspects too far
+        // apart re-bakes the world at the new aspect — the one global re-decide
+        // allowed, and it morphs (SPEC-10 §3.1).
+        if fitMode, bounds.height > 1 {
+            let viewAspect = bounds.width / bounds.height
+            if abs(viewAspect / world.aspect - 1) > Self.aspectHysteresis {
+                world.rebake(aspect: viewAspect)
+                camera.rect = world.worldBounds
+                rebuildTiles(morph: true)
+            }
+        }
+        presentTiles()
+        overlayLayer.setNeedsDisplay()
     }
 
     // MARK: SwiftUI → view
 
     func apply(controller: ScanController, theme: Theme, version: UInt64, zoomRoot: FSNode?,
-               metric: SizeMetric, selection: FSNode?, selectedExt: ExtKey?,
+               zoomRequestID: Int, metric: SizeMetric, selection: FSNode?, selectedExt: ExtKey?,
                searchMatchIDs: Set<ObjectIdentifier>, highlightVersion: Int) {
         self.controller = controller
-        let oldZoomRoot = self.zoomRoot   // capture before the assignment below (for zoom animation)
-        let oldMetric = self.metric
 
         let themeChanged = isDark != theme.isDark
         self.theme = theme
         self.isDark = theme.isDark
         if themeChanged { rebuildThemeColors() }
 
-        let structural = version != self.version || zoomRoot !== self.zoomRoot
-            || metric != self.metric || themeChanged
+        // The world's root is the *scan* root — the camera navigates inside it.
+        var root = zoomRoot
+        while let parent = root?.parent { root = parent }
+        let rootChanged = root !== scanRoot
+
+        let dataChanged = version != self.version || metric != self.metric || themeChanged
+        let navRequested = zoomRequestID != self.zoomRequestID && self.zoomRequestID != .min
+        let firstApply = self.zoomRequestID == .min
         let highlightChanged = selectedExt != self.selectedExt
             || highlightVersion != self.highlightVersion || searchMatchIDs != self.searchMatchIDs
         let selectionChanged = selection !== self.selection
 
         self.version = version
         self.zoomRoot = zoomRoot
+        self.zoomRequestID = zoomRequestID
         self.metric = metric
         self.selectedExt = selectedExt
         self.searchMatchIDs = searchMatchIDs
         self.highlightVersion = highlightVersion
         self.selection = selection
+        self.scanRoot = root
 
-        if structural {
-            // A pure zoom navigation (from the treemap or the outline) animates the camera;
-            // anything else (scan update, metric, theme) relays out instantly.
-            if zoomRoot !== oldZoomRoot, let oldRoot = oldZoomRoot, let newRoot = zoomRoot,
-               zoomLink == nil, !inLiveResize, !instances.isEmpty,
-               startZoomAnimation(from: oldRoot, to: newRoot) {
-                overlayLayer.setNeedsDisplay()
-            } else if zoomLink != nil, zoomRoot === oldZoomRoot, metric == oldMetric, !themeChanged {
-                // Version-only bump (the 10 Hz scan tick, an FSEvents dirty-dot
-                // repaint) while the camera animates: defer the relayout to the
-                // end of the animation instead of cancelling it — otherwise the
-                // push-in can never complete during a live scan.
-                pendingRelayout = true
-            } else {
-                if zoomLink != nil { cancelZoom() }
-                relayout()
-                presentTiles()
-                overlayLayer.setNeedsDisplay()
+        guard let root else {
+            tiles = []; instances = []; regions = [:]; regionsBuilt = false
+            renderer.upload(instances: [], previous: nil)
+            presentTiles()
+            overlayLayer.setNeedsDisplay()
+            return
+        }
+        world.sync(root: root, metric: metric, version: version)
+
+        if rootChanged || firstApply {
+            // A new scan (or first appearance): fresh world, camera at fit.
+            cancelAnimations()
+            fitMode = true
+            if bounds.width > 1, bounds.height > 1 {
+                let viewAspect = bounds.width / bounds.height
+                if abs(viewAspect / world.aspect - 1) > Self.aspectHysteresis {
+                    world.rebake(aspect: viewAspect)
+                }
             }
-        } else {
+            camera.rect = world.worldBounds
+            rebuildTiles(morph: false)
+            presentTiles()
+            overlayLayer.setNeedsDisplay()
+            return
+        }
+
+        if dataChanged {
+            // Scan tick / FSEvents refresh / metric change: entries revalidate
+            // lazily (ε-local), and whatever moved morphs (SPEC-10 §3.4). A pure
+            // theme change only recolours — no motion to animate.
+            rebuildTiles(morph: !themeChanged)
+            presentTiles()
+            overlayLayer.setNeedsDisplay()
+        }
+
+        if navRequested, let target = zoomRoot {
+            // Explicit navigation (double-click, outline, breadcrumb, ⌘↑): an
+            // animated camera fit — the world does not move.
+            if let rect = world.worldRect(of: target, root: root) {
+                animateCamera(to: target === root ? world.worldBounds : fitTarget(for: rect))
+                fitMode = target === root
+            }
+        }
+
+        if !dataChanged {
             if selectionChanged && selection != nil && !regionsBuilt {
-                relayout()               // need the region map to outline the new selection
+                rebuildTiles(morph: false)   // need the region map to outline the new selection
                 presentTiles()
             } else if highlightChanged {
-                computeColors()          // dimming changed; rects unchanged → repack (Metal folds dim in)
+                repackInstances()            // dimming changed; rects unchanged → repack
                 presentTiles()
             }
             if selectionChanged { overlayLayer.setNeedsDisplay() }
@@ -367,59 +480,127 @@ final class TreemapNSView: NSView, CALayerDelegate {
                             Float(ns.blueComponent), Float(ns.alphaComponent))
     }
 
-    // MARK: Resize (AppKit-driven — the hot path)
+    // MARK: Resize (AppKit-driven — now a camera move)
 
     override func setFrameSize(_ newSize: NSSize) {
-        let changed = newSize != frame.size
+        let oldSize = frame.size
+        let changed = newSize != oldSize
         super.setFrameSize(newSize)
         guard changed else { return }
-        // A resize mid-zoom (split-divider drag — not a window live-resize) would
-        // render the old layout's camera over the new layout: fast-forward to the
-        // end state first, then lay out at the new size below.
-        if zoomLink != nil { finishZoom() }
         overlayLayer.frame = bounds
-        // Backing-layer frame is managed by AppKit; we only resize the drawable + redraw.
-        let scale = window?.backingScaleFactor ?? 2
-        metalLayer.drawableSize = CGSize(width: bounds.width * scale, height: bounds.height * scale)
+        updateDrawableSize(pooled: inLiveResize)
         // This frame's present must stay atomic with the bounds change (no
         // band behind a split-divider drag); reverted below unless a window
         // live-resize keeps the synchronous path on.
         metalLayer.presentsWithTransaction = true
-        // The squarified layout is now monotone under resize (TreemapLayout freezes the
-        // discrete row/orientation/recurse decisions and reruns only continuous geometry),
-        // so a full relayout every frame flows smoothly — no freeze/settle needed.
-        relayout()
+        if fitMode {
+            camera.rect = world.worldBounds
+        } else if oldSize.width > 1, oldSize.height > 1 {
+            // Free camera: keep the scale, reveal more/less world (map-window feel).
+            let cx = camera.rect.midX, cy = camera.rect.midY
+            let w = camera.rect.width * newSize.width / oldSize.width
+            let h = camera.rect.height * newSize.height / oldSize.height
+            camera.rect = clampedViewport(CGRect(x: cx - w / 2, y: cy - h / 2, width: w, height: h))
+        }
+        maybeRebuild()
         presentTiles()
         overlayLayer.setNeedsDisplay()
         if !inLiveResize { metalLayer.presentsWithTransaction = false }
     }
 
-    // MARK: Layout (size-dependent placement + colours)
+    // MARK: World → GPU (the only non-camera work)
 
-    private func relayout() {
-        pendingRelayout = false   // any relayout consumes a deferred one
-        hovered = nil
-        guard let controller, let zoomRoot, bounds.width > 1, bounds.height > 1 else {
-            tiles = []; instances.removeAll(keepingCapacity: true)
-            regions = [:]; regionsBuilt = false
+    /// Rebuild the LOD tile set for the current camera and pack it into GPU
+    /// instances. `morph` pairs each tile with its previous world rect (or its
+    /// nearest ancestor's) and animates the transition.
+    private func rebuildTiles(morph: Bool) {
+        guard let controller, let root = scanRoot, bounds.width > 1, bounds.height > 1,
+              camera.rect.width > 0, camera.rect.height > 0 else {
+            tiles = []; instances = []; regions = [:]; regionsBuilt = false
+            renderer.upload(instances: [], previous: nil)
             return
         }
-        let rect = bounds.insetBy(dx: 1, dy: 1)
-        let rootFiles = rootFileTiles(for: zoomRoot, controller: controller)
-        let needRegions = selection != nil
-        let result = controller.treemapLayout(root: zoomRoot, rect: rect, rootFiles: rootFiles,
-                                              needsRegions: needRegions)
+        hovered = nil
+        let scale = camera.scale(viewSize: bounds.size)
+        let needsRegions = selection != nil
+        let result = world.build(root: root, visible: camera.rect, scale: scale,
+                                 needsRegions: needsRegions, files: { [weak self] node in
+            self?.fileTiles(for: node, controller: controller)
+        })
         tiles = result.tiles
         regions = result.regions
-        regionsBuilt = needRegions
-        computeColors()
+        regionsBuilt = needsRegions
+        builtRect = camera.rect.insetBy(dx: -camera.rect.width * TreemapWorld.buildMargin,
+                                        dy: -camera.rect.height * TreemapWorld.buildMargin)
+        builtScale = scale
+        if result.pendingFiles { scheduleFileRetry() }
+
+        // Morph pairing: previous world rect per tile key, falling back to the
+        // nearest ancestor's previous rect (a newly expanded child grows out of
+        // its parent — the map's "tile split").
+        var previous: [TileInstance]? = nil
+        let doMorph = morph && !lastRects.isEmpty && !inLiveResize
+        packInstances()
+        if doMorph {
+            var prev = instances
+            for i in tiles.indices {
+                let key = TreemapWorld.TileKey(tiles[i])
+                let prevRect = lastRects[key] ?? ancestorRect(for: tiles[i].node)
+                if let prevRect {
+                    prev[i].origin.x = Float(prevRect.minX - rebaseOrigin.x)
+                    prev[i].origin.z = Float(prevRect.minY - rebaseOrigin.y)
+                    prev[i].size.x = Float(prevRect.width)
+                    prev[i].size.z = Float(prevRect.height)
+                }
+            }
+            previous = prev
+        }
+        var rects: [TreemapWorld.TileKey: CGRect] = [:]
+        rects.reserveCapacity(tiles.count)
+        for tile in tiles { rects[TreemapWorld.TileKey(tile)] = tile.rect }
+        lastRects = rects
+
+        renderer.upload(instances: instances, previous: previous)
+        if previous != nil { startMorph() } else { morphT = 1 }
     }
 
-    /// Rebuild the GPU `instances` from the current tiles. Size is read once per tile
-    /// (into `sizeScratch`) and reused for both the max pass and the weight, halving
-    /// the atomic loads; `instances` keeps its buffer capacity across frames.
-    private func computeColors() {
+    /// Nearest ancestor of `node` that had a rect in the previous build.
+    private func ancestorRect(for node: FSNode) -> CGRect? {
+        var cur: FSNode? = node
+        while let n = cur {
+            if let r = lastRects[TreemapWorld.TileKey(id: ObjectIdentifier(n), isFileBlock: false, fileName: nil)] {
+                return r
+            }
+            cur = n.parent
+        }
+        return nil
+    }
+
+    /// Rebuild the camera-dependent parts only when the camera leaves the built
+    /// margin or its scale drifts past the LOD band. Pure camera frames skip this.
+    private func maybeRebuild() {
+        guard scanRoot != nil else { return }
+        guard builtRect.width > 0 else {
+            // Nothing built yet (the first apply ran before the view had a size).
+            rebuildTiles(morph: false)
+            return
+        }
+        let scale = camera.scale(viewSize: bounds.size)
+        let scaleDrift = max(scale.sx / builtScale.sx, scale.sy / builtScale.sy)
+        let outgrown = !builtRect.contains(camera.rect)
+        if outgrown || scaleDrift > 1.3 || scaleDrift < 0.77 {
+            // Morph on zoom-driven rebuilds (LOD splits/merges — the Maps feel);
+            // pan-driven edge fills appear instantly.
+            rebuildTiles(morph: scaleDrift > 1.3 || scaleDrift < 0.77)
+        }
+    }
+
+    /// Pack `tiles` into GPU `instances`: camera-rebased world rect on the ground
+    /// plane (Float precision holds because coordinates are relative to the built
+    /// visible rect — the floating origin), packed sRGB colour, dim folded in.
+    private func packInstances() {
         let n = tiles.count
+        rebaseOrigin = builtRect.origin
         let key = ColorKey(isDark: isDark, version: version)
         if colorKey != key {
             hueIndexCache.removeAll(keepingCapacity: true)
@@ -433,22 +614,14 @@ final class TreemapNSView: NSView, CALayerDelegate {
             sizeScratch[i] = s
             if s > maxSize { maxSize = s }
         }
-        packInstances(denom: Double(maxSize))
-    }
-
-    /// Pack `tiles` into GPU `instances`: world rect on the ground plane
-    /// (top-left, height 0), packed sRGB colour, dim folded in. Sub-pixel tiles are
-    /// culled here — `instances` may be shorter than `tiles`; hit-testing uses `tiles`.
-    private func packInstances(denom: Double) {
-        let n = tiles.count
-        instances.removeAll(keepingCapacity: true)
-        instances.reserveCapacity(n)
+        let denom = Double(maxSize)
         let highlightName = selectedExt?.displayName
         let hasSearch = highlightName == nil && !searchMatchIDs.isEmpty
+        instances.removeAll(keepingCapacity: true)
+        instances.reserveCapacity(n)
         for i in 0..<n {
             let tile = tiles[i]
             let r = tile.rect
-            if r.width <= 0.5 || r.height <= 0.5 { continue }
             let weight = min(1.0, max(0.0, pow(Double(sizeScratch[i]) / denom, 0.40)))
             var dim: Float = 0
             if let highlightName {
@@ -458,15 +631,57 @@ final class TreemapNSView: NSView, CALayerDelegate {
                 dim = 1
             }
             instances.append(TileInstance(
-                origin: SIMD4<Float>(Float(r.minX), 0, Float(r.minY), 0),
+                origin: SIMD4<Float>(Float(r.minX - rebaseOrigin.x), 0, Float(r.minY - rebaseOrigin.y), 0),
                 size: SIMD4<Float>(Float(r.width), 0, Float(r.height), dim),
                 color: tileColor(for: tile, weight: weight)))
         }
     }
 
+    /// Highlight/search change: same tiles, new dims — repack and re-upload.
+    private func repackInstances() {
+        packInstances()
+        renderer.upload(instances: instances, previous: nil)
+        morphT = 1
+    }
+
+    private func tileSize(_ tile: TreemapWorld.Tile) -> Int64 {
+        if let file = tile.file { return file.size }
+        return tile.isFileBlock ? tile.node.directFilesSize(metric) : tile.node.size(metric)
+    }
+
+    /// File tiles for a folder whose block crossed the file-LOD threshold.
+    /// `nil` = listing still loading (a one-shot rebuild retries shortly).
+    private func fileTiles(for node: FSNode, controller: ScanController) -> [FileTileInfo]? {
+        guard controller.isHostScan, !controller.isScanning else { return [] }
+        let items = controller.filesIn(node)
+        if items.isEmpty && node.directFileCount > 0 {
+            let id = ObjectIdentifier(node)
+            let attempts = fileAttempts[id, default: 0]
+            if attempts < 3 {
+                fileAttempts[id] = attempts + 1
+                return nil   // in flight
+            }
+            return []        // failed/blocked: keep the aggregate block
+        }
+        return items.map {
+            FileTileInfo(name: $0.name, size: $0.size(metric), extName: OutlineRowView.extDisplay($0.name))
+        }
+    }
+
+    private func scheduleFileRetry() {
+        guard !fileRetryScheduled else { return }
+        fileRetryScheduled = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+            guard let self else { return }
+            self.fileRetryScheduled = false
+            self.rebuildTiles(morph: true)
+            self.presentTiles()
+        }
+    }
+
     /// sRGB RGBA for a tile, memoised in a bounded `(hueIndex, bucket)` LUT —
-    /// no per-frame `NSColor`/hashing on the resize hot path.
-    private func tileColor(for tile: TreemapTile, weight: Double) -> SIMD4<Float> {
+    /// no per-frame `NSColor`/hashing on the hot path.
+    private func tileColor(for tile: TreemapWorld.Tile, weight: Double) -> SIMD4<Float> {
         let hueIdx: Int
         if let ext = tile.file?.extName {
             hueIdx = Theme.stableIndex(ext, paletteCount)
@@ -490,56 +705,209 @@ final class TreemapNSView: NSView, CALayerDelegate {
         return v
     }
 
-    /// Push the current tiles to screen (a GPU render). During a zoom animation
-    /// `zoomViewport` overrides the full-bounds camera so the map pushes toward /
-    /// pulls back from a folder (same tiles, a moving orthographic camera).
+    /// Push the current world to screen through the camera — a pure GPU render.
     private func presentTiles() {
-        let viewport = zoomViewport ?? CGRect(origin: .zero, size: bounds.size)
-        renderer.render(into: metalLayer, instances: instances,
-                        camera: Camera.ortho(viewport: viewport),
-                        clearColor: backgroundComps, borderColor: borderComps)
+        let viewport = camera.rect.offsetBy(dx: -rebaseOrigin.x, dy: -rebaseOrigin.y)
+        renderer.draw(into: metalLayer,
+                      camera: Camera.ortho(viewport: viewport),
+                      pointsPerUnit: camera.scale(viewSize: bounds.size),
+                      morph: morphT,
+                      clearColor: backgroundComps,
+                      borderColor: borderComps,
+                      contentSize: contentPixelSize)
     }
 
-    private func tileSize(_ tile: TreemapTile) -> Int64 {
-        if let file = tile.file { return file.size }
-        return tile.isFileBlock ? tile.node.directFilesSize(metric) : tile.node.size(metric)
+    // MARK: Camera navigation (SPEC-10 M2 — the map)
+
+    /// Expand a node's rect to the world aspect (the camera rect's invariant
+    /// aspect), so a navigation fit never changes the on-screen stretch.
+    private func fitTarget(for rect: CGRect) -> CGRect {
+        let aspect = world.aspect
+        var w = rect.width, h = rect.height
+        if w / h > aspect { h = w / aspect } else { w = h * aspect }
+        // Slight breathing room around the target folder.
+        w *= 1.02; h *= 1.02
+        return clampedViewport(CGRect(x: rect.midX - w / 2, y: rect.midY - h / 2, width: w, height: h))
     }
 
-    /// The zoom root's own files as tiles (SPEC-05), memoised by (zoom, metric,
-    /// version) so a resize reuses the mapping instead of re-deriving extension
-    /// labels for up to `maxFilesPerFolder` files every frame.
-    private func rootFileTiles(for zoom: FSNode, controller: ScanController) -> [FileTileInfo]? {
-        guard controller.isHostScan, !controller.isScanning else { return nil }
-        let key = RootFilesKey(zoom: ObjectIdentifier(zoom), metric: metric, version: version)
-        if rootFilesKey == key { return rootFilesCache }
-        let items = controller.filesIn(zoom)
-        let mapped: [FileTileInfo]? = items.isEmpty ? nil : items.map {
-            FileTileInfo(name: $0.name, size: $0.size(metric), extName: OutlineRowView.extDisplay($0.name))
+    /// Keep the viewport inside the world (when smaller) and snap to fit (when
+    /// it would exceed it). Also bounds the zoom-in so Double math stays sane.
+    private func clampedViewport(_ rect: CGRect) -> CGRect {
+        var r = rect
+        let wb = world.worldBounds
+        let minW = wb.width / 1_000_000
+        if r.width < minW {
+            let f = minW / r.width
+            r = CGRect(x: r.midX - r.width * f / 2, y: r.midY - r.height * f / 2,
+                       width: r.width * f, height: r.height * f)
         }
-        rootFilesCache = mapped
-        rootFilesKey = key
-        return mapped
+        if r.width >= wb.width || r.height >= wb.height {
+            return wb
+        }
+        if r.minX < wb.minX { r.origin.x = wb.minX }
+        if r.minY < wb.minY { r.origin.y = wb.minY }
+        if r.maxX > wb.maxX { r.origin.x = wb.maxX - r.width }
+        if r.maxY > wb.maxY { r.origin.y = wb.maxY - r.height }
+        return r
     }
 
-    // MARK: Drawing
+    override func scrollWheel(with event: NSEvent) {
+        guard scanRoot != nil else { return }
+        let isGesture = event.phase != [] || event.momentumPhase != []
+        if isGesture {
+            // Trackpad: two-finger pan — the content follows the fingers
+            // (`scrollingDelta` already folds in the natural-scrolling preference).
+            let delta = CGSize(width: event.scrollingDeltaX, height: event.scrollingDeltaY)
+            camera.pan(byView: delta, viewSize: bounds.size)
+            camera.rect = clampedViewport(camera.rect)
+            fitMode = camera.rect == world.worldBounds
+        } else {
+            // Mouse wheel: zoom toward the cursor (the Maps convention).
+            let p = topLeftPoint(event)
+            let factor = pow(1.1, event.scrollingDeltaY)
+            zoomCamera(by: factor, anchor: p)
+        }
+        cameraMoved()
+    }
+
+    override func magnify(with event: NSEvent) {
+        guard scanRoot != nil else { return }
+        zoomCamera(by: 1 + event.magnification, anchor: topLeftPoint(event))
+        cameraMoved()
+    }
+
+    private func zoomCamera(by factor: CGFloat, anchor: CGPoint) {
+        guard factor > 0 else { return }
+        camera.zoom(by: factor, anchorView: anchor, viewSize: bounds.size)
+        camera.rect = clampedViewport(camera.rect)
+        fitMode = camera.rect == world.worldBounds
+    }
+
+    /// Common postlude of every interactive camera move.
+    private func cameraMoved() {
+        camAnimating = false
+        maybeRebuild()
+        presentTiles()
+        overlayLayer.setNeedsDisplay()
+        scheduleFocusDerivation()
+    }
+
+    /// After the camera settles, derive the deepest folder containing the view —
+    /// the breadcrumb/list follow the map (`zoomRoot` as a derived value).
+    private func scheduleFocusDerivation() {
+        focusWork?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            guard let self, let controller = self.controller, let root = self.scanRoot else { return }
+            let focus = self.world.focusNode(root: root, visible: self.camera.rect)
+            if focus !== controller.zoomRoot { controller.cameraDidFocus(focus) }
+        }
+        focusWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25, execute: work)
+    }
+
+    /// Mouse location in top-left view coordinates (the world's orientation).
+    private func topLeftPoint(_ event: NSEvent) -> CGPoint {
+        let p = convert(event.locationInWindow, from: nil)
+        return CGPoint(x: p.x, y: bounds.height - p.y)
+    }
+
+    // MARK: Animation clock (camera fits + morphs share one link)
+
+    private func animateCamera(to target: CGRect) {
+        camFrom = camera.rect
+        camTo = target
+        camStart = -1
+        camAnimating = true
+        ensureLink()
+    }
+
+    private func startMorph() {
+        morphT = 0
+        morphStart = -1
+        ensureLink()
+    }
+
+    private func ensureLink() {
+        guard animLink == nil else { return }
+        let link = displayLink(target: self, selector: #selector(animStep(_:)))
+        link.add(to: .main, forMode: .common)
+        animLink = link
+    }
+
+    @objc private func animStep(_ link: CADisplayLink) {
+        var active = false
+        if camAnimating {
+            if camStart < 0 { camStart = link.timestamp }
+            let t = min(1, (link.timestamp - camStart) / Self.camDuration)
+            camera.rect = interpolatedViewport(easeInOut(t))
+            if t >= 1 {
+                camAnimating = false
+                camera.rect = camTo
+                fitMode = camera.rect == world.worldBounds
+                maybeRebuild()
+                overlayLayer.setNeedsDisplay()
+                scheduleFocusDerivation()
+            } else {
+                active = true
+            }
+        }
+        if morphT < 1 {
+            if morphStart < 0 { morphStart = link.timestamp }
+            let t = min(1, (link.timestamp - morphStart) / Self.morphDuration)
+            morphT = Float(easeInOut(t))
+            if t < 1 { active = true }
+        }
+        presentTiles()
+        if !active {
+            animLink?.invalidate()
+            animLink = nil
+        }
+    }
+
+    private func cancelAnimations() {
+        animLink?.invalidate()
+        animLink = nil
+        camAnimating = false
+        morphT = 1
+        focusWork?.cancel()
+    }
+
+    /// Geometric interpolation of the viewport (constant-velocity zoom) between the
+    /// two framings, `e` already eased.
+    private func interpolatedViewport(_ e: Double) -> CGRect {
+        let a = camFrom, b = camTo
+        let aw = max(Double(a.width), 0.5), ah = max(Double(a.height), 0.5)
+        let w = aw * pow(Double(b.width) / aw, e)
+        let h = ah * pow(Double(b.height) / ah, e)
+        let cx = Double(a.midX) + (Double(b.midX) - Double(a.midX)) * e
+        let cy = Double(a.midY) + (Double(b.midY) - Double(a.midY)) * e
+        return CGRect(x: cx - w / 2, y: cy - h / 2, width: w, height: h)
+    }
+
+    private func easeInOut(_ t: Double) -> Double {
+        t < 0.5 ? 4 * t * t * t : 1 - pow(-2 * t + 2, 3) / 2
+    }
+
+    // MARK: Drawing (CG overlay — follows the camera)
 
     func draw(_ layer: CALayer, in ctx: CGContext) {
         // The layer context is native Core Graphics: bottom-left, y-up, text upright.
-        // The rects are top-left, so each is flipped into this space at draw time
-        // (`flip`). No context or text-matrix flips — so glyphs can never mirror.
+        // World rects are converted to top-left view coordinates via the camera,
+        // then flipped into this space at draw time (`flip`).
         guard layer === overlayLayer else { return }
         drawOverlay(in: ctx, size: layer.bounds.size)
     }
 
-    /// Flip a top-left tile rect into the context's native bottom-left space.
+    /// Flip a top-left view rect into the context's native bottom-left space.
     private func flip(_ r: CGRect, _ height: CGFloat) -> CGRect {
         CGRect(x: r.minX, y: height - r.maxY, width: r.width, height: r.height)
     }
 
     private func drawOverlay(in ctx: CGContext, size: CGSize) {
-        guard zoomLink == nil else { return }   // hidden during a zoom (CG can't follow the Metal camera)
-        if let selection, let sel = selectionRect(for: selection) {
-            let r = flip(sel, size.height)
+        guard !camAnimating else { return }   // redrawn when the camera lands
+        if let selection, let sel = selectionRect(for: selection),
+           case let r = flip(camera.worldToView(sel, viewSize: bounds.size), size.height),
+           r.intersects(CGRect(origin: .zero, size: size)) {
             // Spotlight: dim everything outside the selected region.
             ctx.setFillColor(Self.spotlightDimCG)
             ctx.addRect(CGRect(origin: .zero, size: size))
@@ -560,7 +928,7 @@ final class TreemapNSView: NSView, CALayerDelegate {
             ctx.restoreGState()
         }
         if let hovered {
-            let r = flip(hovered.rect, size.height)
+            let r = flip(camera.worldToView(hovered.rect, viewSize: bounds.size), size.height)
             ctx.setStrokeColor(Self.hoverCG)
             ctx.setLineWidth(1.5)
             ctx.stroke(r.insetBy(dx: 0.75, dy: 0.75))
@@ -576,14 +944,15 @@ final class TreemapNSView: NSView, CALayerDelegate {
         return false
     }
 
-    /// Bounding region of a directory in the current layout, falling back to the
+    /// Bounding region of a directory in the current build, falling back to the
     /// nearest ancestor that has one (the tile it visually lives inside).
     private func selectionRect(for node: FSNode) -> CGRect? {
-        if node === zoomRoot { return nil }
         var cur: FSNode? = node
         while let n = cur {
-            if let r = regions[ObjectIdentifier(n)] { return r }
-            if n === zoomRoot { break }
+            if let r = regions[ObjectIdentifier(n)] {
+                // Selecting the whole visible world would spotlight everything: skip.
+                return r.contains(camera.rect) ? nil : r
+            }
             cur = n.parent
         }
         return nil
@@ -592,14 +961,13 @@ final class TreemapNSView: NSView, CALayerDelegate {
     // MARK: Hit testing & interaction
 
     /// The topmost tile at `point` (a mouse location in view coordinates). Mouse
-    /// coordinates arrive bottom-left; the tiles are stored top-left (matching the
-    /// layout), so flip Y before hit-testing. Sub-pixel tiles are skipped with the
-    /// same 0.5 pt threshold as the renderers — hover/click/menu must never land
+    /// coordinates arrive bottom-left; the camera converts to world space. Tiles
+    /// below the sub-pixel cull can't be hit — hover/click/menu must never land
     /// on a tile the user can't see. Named to avoid clashing with `NSView.hitTest(_:)`.
-    private func tileAt(_ point: CGPoint) -> TreemapTile? {
-        let p = CGPoint(x: point.x, y: bounds.height - point.y)
-        for tile in tiles.reversed()
-        where tile.rect.width > 0.5 && tile.rect.height > 0.5 && tile.rect.contains(p) {
+    private func tileAt(_ point: CGPoint) -> TreemapWorld.Tile? {
+        let pTop = CGPoint(x: point.x, y: bounds.height - point.y)
+        let p = camera.viewToWorld(pTop, viewSize: bounds.size)
+        for tile in tiles.reversed() where tile.rect.contains(p) {
             return tile
         }
         return nil
@@ -617,7 +985,7 @@ final class TreemapNSView: NSView, CALayerDelegate {
     }
 
     override func mouseMoved(with event: NSEvent) {
-        guard zoomLink == nil else { return }   // ignore hover while a zoom animates
+        guard !camAnimating else { return }   // ignore hover while the camera flies
         let p = convert(event.locationInWindow, from: nil)
         let hit = tileAt(p)
         if hit?.rect != hovered?.rect {
@@ -635,11 +1003,11 @@ final class TreemapNSView: NSView, CALayerDelegate {
     }
 
     override func mouseUp(with event: NSEvent) {
-        guard zoomLink == nil else { return }   // let a running zoom animation finish
+        guard !camAnimating else { return }   // let a running camera flight finish
         let tile = tileAt(convert(event.locationInWindow, from: nil))
         if event.clickCount >= 2 {
-            // Double-click: open a file tile, dive into a folder tile (animated), or pop
-            // back out on a leaf/gap — a mouse-only way to zoom.
+            // Double-click: open a file tile, dive into a folder tile (an animated
+            // camera fit via the controller round-trip), or pull back on a leaf/gap.
             guard let controller else { return }
             if let tile {
                 if let file = tile.file {
@@ -647,7 +1015,7 @@ final class TreemapNSView: NSView, CALayerDelegate {
                         controller.openItem((base == "/" ? "/" : base + "/") + file.name)
                     }
                 } else if tile.node.isDirectory {
-                    controller.zoom(into: tile.node)   // apply() animates the transition
+                    controller.zoom(into: tile.node)   // apply() flies the camera there
                 } else {
                     controller.zoomOut()
                 }
@@ -659,132 +1027,7 @@ final class TreemapNSView: NSView, CALayerDelegate {
         }
     }
 
-    // MARK: Animated zoom (a moving orthographic camera)
-
-    private var zoomLink: CADisplayLink?
-    private var zoomFrom = CGRect.zero
-    private var zoomTo = CGRect.zero
-    private var zoomStart: CFTimeInterval = -1
-    private var zoomViewport: CGRect?              // nil = full-bounds camera (no animation)
-    private var zoomOnDone: (() -> Void)?
-    /// A version bump arrived mid-animation; the relayout it asked for runs when
-    /// the camera lands (consumed by `relayout()`).
-    private var pendingRelayout = false
-    private static let zoomDuration: CFTimeInterval = 0.5
-
-    /// Route a zoom navigation (from *any* entry point — treemap double-click, the left
-    /// outline, ⌘↑, breadcrumb) into an animated camera move. `apply()` calls this when the
-    /// zoom root changed. Returns false when it can't animate (e.g. a sideways jump between
-    /// unrelated branches), so the caller falls back to an instant relayout.
-    private func startZoomAnimation(from oldRoot: FSNode, to newRoot: FSNode) -> Bool {
-        let full = CGRect(origin: .zero, size: bounds.size)
-        if isUnder(newRoot, orIs: oldRoot) {
-            // Zoom IN: newRoot sits inside the *current* (old) layout, still in `tiles`. Push
-            // the camera onto its region, keeping the old tiles; settle to the new layout at end.
-            guard let r = regionRect(for: newRoot, in: tiles), r.width > 1, r.height > 1 else { return false }
-            animateZoom(from: full, to: r) { [weak self] in self?.settleAfterZoom() }
-            return true
-        } else if isUnder(oldRoot, orIs: newRoot) {
-            // Zoom OUT: lay out the new (parent) view now, then pull the camera back from where
-            // the old root sits in it to the full view.
-            relayout()
-            guard let r = regionRect(for: oldRoot, in: tiles), r.width > 1, r.height > 1 else {
-                presentTiles(); overlayLayer.setNeedsDisplay(); return true
-            }
-            animateZoom(from: r, to: full) { [weak self] in
-                self?.presentTiles(); self?.overlayLayer.setNeedsDisplay()
-            }
-            return true
-        }
-        return false   // unrelated branches → instant relayout
-    }
-
-    private func settleAfterZoom() {
-        relayout()
-        presentTiles()
-        overlayLayer.setNeedsDisplay()
-    }
-
-    /// Bounding rect of `ancestor`'s subtree within `tileList` (union of its tiles) — where a
-    /// folder sits in a layout, without depending on the (optional) region map being built.
-    private func regionRect(for ancestor: FSNode, in tileList: [TreemapTile]) -> CGRect? {
-        var union: CGRect?
-        for tile in tileList where isUnder(tile.node, orIs: ancestor) {
-            union = union.map { $0.union(tile.rect) } ?? tile.rect
-        }
-        return union
-    }
-
-    private func isUnder(_ node: FSNode, orIs ancestor: FSNode) -> Bool {
-        var cur: FSNode? = node
-        while let n = cur {
-            if n === ancestor { return true }
-            cur = n.parent
-        }
-        return false
-    }
-
-    private func animateZoom(from: CGRect, to: CGRect, onDone: @escaping () -> Void) {
-        zoomFrom = from
-        zoomTo = to
-        zoomStart = -1
-        zoomViewport = from
-        zoomOnDone = onDone
-        let link = displayLink(target: self, selector: #selector(zoomStep(_:)))
-        link.add(to: .main, forMode: .common)
-        zoomLink = link
-        presentTiles()                      // first frame at `from`
-        overlayLayer.setNeedsDisplay()       // clear the CG overlay (it can't follow the camera)
-    }
-
-    @objc private func zoomStep(_ link: CADisplayLink) {
-        if zoomStart < 0 { zoomStart = link.timestamp }
-        let t = min(1, (link.timestamp - zoomStart) / Self.zoomDuration)
-        zoomViewport = interpolatedViewport(easeInOut(t))
-        presentTiles()
-        if t >= 1 { finishZoom() }
-    }
-
-    private func finishZoom() {
-        zoomLink?.invalidate()
-        zoomLink = nil
-        zoomViewport = nil
-        let done = zoomOnDone
-        zoomOnDone = nil
-        done?()                             // commit the zoom → apply → relayout → full-view present
-        if pendingRelayout {                // deferred scan-tick relayout (zoom-out path doesn't relayout)
-            relayout()
-            presentTiles()
-            overlayLayer.setNeedsDisplay()
-        }
-    }
-
-    /// Cancel a zoom without committing it (e.g. the view leaves its window mid-animation),
-    /// so the `CADisplayLink → self` retain cycle can't outlive the view.
-    private func cancelZoom() {
-        zoomLink?.invalidate()
-        zoomLink = nil
-        zoomViewport = nil
-        zoomOnDone = nil
-    }
-
-    /// Geometric interpolation of the viewport (constant-velocity zoom) between the two
-    /// framings, `e` already eased.
-    private func interpolatedViewport(_ e: Double) -> CGRect {
-        let a = zoomFrom, b = zoomTo
-        let aw = max(Double(a.width), 0.5), ah = max(Double(a.height), 0.5)
-        let w = aw * pow(Double(b.width) / aw, e)
-        let h = ah * pow(Double(b.height) / ah, e)
-        let cx = Double(a.midX) + (Double(b.midX) - Double(a.midX)) * e
-        let cy = Double(a.midY) + (Double(b.midY) - Double(a.midY)) * e
-        return CGRect(x: cx - w / 2, y: cy - h / 2, width: w, height: h)
-    }
-
-    private func easeInOut(_ t: Double) -> Double {
-        t < 0.5 ? 4 * t * t * t : 1 - pow(-2 * t + 2, 3) / 2
-    }
-
-    private func hoverInfo(for tile: TreemapTile) -> HoverInfo {
+    private func hoverInfo(for tile: TreemapWorld.Tile) -> HoverInfo {
         if let file = tile.file {
             return HoverInfo(title: file.name, isDirectory: false, sizeText: Format.bytes(file.size))
         }
@@ -805,7 +1048,7 @@ final class TreemapNSView: NSView, CALayerDelegate {
     // MARK: Context menu
 
     override func menu(for event: NSEvent) -> NSMenu? {
-        guard zoomLink == nil else { return nil }   // no context menu mid-zoom
+        guard !camAnimating else { return nil }   // no context menu mid-flight
         let p = convert(event.locationInWindow, from: nil)
         guard let tile = tileAt(p), let controller else { return nil }
         let menu = NSMenu()
@@ -843,13 +1086,6 @@ final class TreemapNSView: NSView, CALayerDelegate {
             menu.addItem(ClosureMenuItem(title: "Copy Path (in VM)", symbol: "doc.on.doc") { controller.copyPath(path) })
         }
     }
-}
-
-/// Identifies the inputs that determine the zoom root's file tiles.
-private struct RootFilesKey: Equatable {
-    let zoom: ObjectIdentifier
-    let metric: SizeMetric
-    let version: UInt64
 }
 
 /// An `NSMenuItem` that runs a closure when chosen.

--- a/Sources/SpaceMatters/Views/TreemapView.swift
+++ b/Sources/SpaceMatters/Views/TreemapView.swift
@@ -205,8 +205,16 @@ final class TreemapNSView: NSView, CALayerDelegate {
     /// camera can roam inside without a rebuild.
     private var builtRect = CGRect.zero
     private var builtScale: (sx: CGFloat, sy: CGFloat) = (1, 1)
-    /// World rects of the previous build, keyed by tile identity — morph pairing.
-    private var lastRects: [TreemapWorld.TileKey: CGRect] = [:]
+    /// Morph pairing state, keyed by tile identity, in world coordinates.
+    /// `lastTargets` is where the previous build put each tile; `lastPrevs` is what
+    /// that build was morphing *from* — so a rebuild landing mid-morph can start
+    /// from the state actually displayed (lerp of the two at `morphT`), not snap.
+    private struct TileState {
+        var rect: CGRect
+        var color: SIMD4<Float>
+    }
+    private var lastTargets: [TreemapWorld.TileKey: TileState] = [:]
+    private var lastPrevs: [TreemapWorld.TileKey: TileState] = [:]
     private var hovered: TreemapWorld.Tile?
 
     // Morph clock (structural transitions) + camera animation (navigation fits).
@@ -499,6 +507,7 @@ final class TreemapNSView: NSView, CALayerDelegate {
         guard let controller, let root = scanRoot, bounds.width > 1, bounds.height > 1,
               camera.rect.width > 0, camera.rect.height > 0 else {
             tiles = []; instances = []; regions = [:]; regionsBuilt = false
+            lastTargets = [:]; lastPrevs = [:]
             renderer.upload(instances: [], previous: nil)
             return
         }
@@ -517,45 +526,65 @@ final class TreemapNSView: NSView, CALayerDelegate {
         builtScale = scale
         if result.pendingFiles { scheduleFileRetry() }
 
-        // Morph pairing: previous world rect per tile key, falling back to the
-        // nearest ancestor's previous rect (a newly expanded child grows out of
-        // its parent — the map's "tile split").
-        var previous: [TileInstance]? = nil
-        let doMorph = morph && !lastRects.isEmpty && !inLiveResize
+        // Morph pairing: a tile that existed in the previous build slides from
+        // the state it was *actually displaying* (mid-morph aware) and cross-fades
+        // its colour (the brightness renormalisation stops popping). A tile that
+        // didn't exist appears at its final place — no geometric "growth", which
+        // overlapped neighbours and read as giant squares during a zoom.
+        let doMorph = morph && !lastTargets.isEmpty && !inLiveResize
         packInstances()
+        var previous: [TileInstance]? = nil
         if doMorph {
+            let t = morphT
             var prev = instances
             for i in tiles.indices {
-                let key = TreemapWorld.TileKey(tiles[i])
-                let prevRect = lastRects[key] ?? ancestorRect(for: tiles[i].node)
-                if let prevRect {
-                    prev[i].origin.x = Float(prevRect.minX - rebaseOrigin.x)
-                    prev[i].origin.z = Float(prevRect.minY - rebaseOrigin.y)
-                    prev[i].size.x = Float(prevRect.width)
-                    prev[i].size.z = Float(prevRect.height)
+                guard let target = lastTargets[TreemapWorld.TileKey(tiles[i])] else { continue }
+                var from = target
+                if t < 1, let p = lastPrevs[TreemapWorld.TileKey(tiles[i])] {
+                    from.rect = lerp(p.rect, target.rect, CGFloat(t))
+                    from.color = p.color + (target.color - p.color) * t
                 }
+                prev[i].origin.x = Float(from.rect.minX - rebaseOrigin.x)
+                prev[i].origin.z = Float(from.rect.minY - rebaseOrigin.y)
+                prev[i].size.x = Float(from.rect.width)
+                prev[i].size.z = Float(from.rect.height)
+                prev[i].color = from.color
             }
             previous = prev
         }
-        var rects: [TreemapWorld.TileKey: CGRect] = [:]
-        rects.reserveCapacity(tiles.count)
-        for tile in tiles { rects[TreemapWorld.TileKey(tile)] = tile.rect }
-        lastRects = rects
+        recordMorphState(previous: previous)
 
         renderer.upload(instances: instances, previous: previous)
         if previous != nil { startMorph() } else { morphT = 1 }
     }
 
-    /// Nearest ancestor of `node` that had a rect in the previous build.
-    private func ancestorRect(for node: FSNode) -> CGRect? {
-        var cur: FSNode? = node
-        while let n = cur {
-            if let r = lastRects[TreemapWorld.TileKey(id: ObjectIdentifier(n), isFileBlock: false, fileName: nil)] {
-                return r
+    /// Snapshot the pairing dictionaries for the *next* rebuild.
+    private func recordMorphState(previous: [TileInstance]?) {
+        var targets: [TreemapWorld.TileKey: TileState] = [:]
+        targets.reserveCapacity(tiles.count)
+        var prevs: [TreemapWorld.TileKey: TileState] = [:]
+        if previous != nil { prevs.reserveCapacity(tiles.count) }
+        for i in tiles.indices {
+            let key = TreemapWorld.TileKey(tiles[i])
+            targets[key] = TileState(rect: tiles[i].rect, color: instances[i].color)
+            if let previous {
+                let p = previous[i]
+                prevs[key] = TileState(
+                    rect: CGRect(x: CGFloat(p.origin.x) + rebaseOrigin.x,
+                                 y: CGFloat(p.origin.z) + rebaseOrigin.y,
+                                 width: CGFloat(p.size.x), height: CGFloat(p.size.z)),
+                    color: p.color)
             }
-            cur = n.parent
         }
-        return nil
+        lastTargets = targets
+        lastPrevs = prevs
+    }
+
+    private func lerp(_ a: CGRect, _ b: CGRect, _ t: CGFloat) -> CGRect {
+        CGRect(x: a.minX + (b.minX - a.minX) * t,
+               y: a.minY + (b.minY - a.minY) * t,
+               width: a.width + (b.width - a.width) * t,
+               height: a.height + (b.height - a.height) * t)
     }
 
     /// Rebuild the camera-dependent parts only when the camera leaves the built
@@ -624,6 +653,7 @@ final class TreemapNSView: NSView, CALayerDelegate {
         packInstances()
         renderer.upload(instances: instances, previous: nil)
         morphT = 1
+        recordMorphState(previous: nil)   // future morphs fade from the new colours
     }
 
     private func tileSize(_ tile: TreemapWorld.Tile) -> Int64 {

--- a/Sources/SpaceMatters/Views/TreemapView.swift
+++ b/Sources/SpaceMatters/Views/TreemapView.swift
@@ -315,37 +315,20 @@ final class TreemapNSView: NSView, CALayerDelegate {
 
     private func setScale(_ scale: CGFloat) {
         metalLayer.contentsScale = scale
-        updateDrawableSize(pooled: false)
+        updateDrawableSize()
         presentTiles()
         overlayLayer.contentsScale = scale
         overlayLayer.setNeedsDisplay()
     }
 
-    /// Size the drawable. During a live resize the drawable is *pooled*: rounded up
-    /// to 256-px steps and cropped via `contentsRect`, so the CAMetalLayer's
-    /// IOSurface pool survives the drag instead of reallocating per frame
-    /// (SPEC-10 §3.6 — the profiled hitch source). At rest the size is exact.
-    private func updateDrawableSize(pooled: Bool) {
+    /// Size the drawable to the view exactly. (A pooled drawable + `contentsRect`
+    /// crop was tried per SPEC-10 §3.6 to avoid per-frame IOSurface reallocation
+    /// during a drag, but the crop mapping produced black bands — reverted; with
+    /// resize now being camera-only, the realloc is the only remaining cost.)
+    private func updateDrawableSize() {
         let scale = metalLayer.contentsScale
-        let target = CGSize(width: max(bounds.width * scale, 1), height: max(bounds.height * scale, 1))
-        if pooled {
-            let pw = (Int(target.width) + 255) & ~255
-            let ph = (Int(target.height) + 255) & ~255
-            let current = metalLayer.drawableSize
-            let w = max(CGFloat(pw), current.width)
-            let h = max(CGFloat(ph), current.height)
-            metalLayer.drawableSize = CGSize(width: w, height: h)
-            metalLayer.contentsRect = CGRect(x: 0, y: 0, width: target.width / w, height: target.height / h)
-        } else {
-            metalLayer.drawableSize = target
-            metalLayer.contentsRect = CGRect(x: 0, y: 0, width: 1, height: 1)
-        }
-    }
-
-    /// Pixel size actually displayed (≤ drawableSize when pooled).
-    private var contentPixelSize: CGSize {
-        let scale = metalLayer.contentsScale
-        return CGSize(width: bounds.width * scale, height: bounds.height * scale)
+        metalLayer.drawableSize = CGSize(width: max(bounds.width * scale, 1),
+                                         height: max(bounds.height * scale, 1))
     }
 
     // Synchronous presents (`presentsWithTransaction`) only while the window is
@@ -360,7 +343,6 @@ final class TreemapNSView: NSView, CALayerDelegate {
     override func viewDidEndLiveResize() {
         super.viewDidEndLiveResize()
         metalLayer.presentsWithTransaction = false
-        updateDrawableSize(pooled: false)
         // Aspect hysteresis: a drag that left the window/world aspects too far
         // apart re-bakes the world at the new aspect — the one global re-decide
         // allowed, and it morphs (SPEC-10 §3.1).
@@ -488,7 +470,7 @@ final class TreemapNSView: NSView, CALayerDelegate {
         super.setFrameSize(newSize)
         guard changed else { return }
         overlayLayer.frame = bounds
-        updateDrawableSize(pooled: inLiveResize)
+        updateDrawableSize()
         // This frame's present must stay atomic with the bounds change (no
         // band behind a split-divider drag); reverted below unless a window
         // live-resize keeps the synchronous path on.
@@ -713,8 +695,7 @@ final class TreemapNSView: NSView, CALayerDelegate {
                       pointsPerUnit: camera.scale(viewSize: bounds.size),
                       morph: morphT,
                       clearColor: backgroundComps,
-                      borderColor: borderComps,
-                      contentSize: contentPixelSize)
+                      borderColor: borderComps)
     }
 
     // MARK: Camera navigation (SPEC-10 M2 — the map)
@@ -762,10 +743,16 @@ final class TreemapNSView: NSView, CALayerDelegate {
             camera.rect = clampedViewport(camera.rect)
             fitMode = camera.rect == world.worldBounds
         } else {
-            // Mouse wheel: zoom toward the cursor (the Maps convention).
-            let p = topLeftPoint(event)
-            let factor = pow(1.1, event.scrollingDeltaY)
-            zoomCamera(by: factor, anchor: p)
+            // Mouse wheel: zoom toward the cursor (the Maps convention). Precise
+            // devices report pixel deltas (±tens per notch) where a classic wheel
+            // reports lines (±1–3): normalise to "steps" and bound the per-event
+            // factor so one notch is a smooth ×1.15, never a teleport.
+            guard event.scrollingDeltaY != 0 else { return }
+            let steps = event.hasPreciseScrollingDeltas
+                ? event.scrollingDeltaY / 12
+                : event.scrollingDeltaY
+            let factor = min(2.0, max(0.5, pow(1.15, steps)))
+            zoomCamera(by: factor, anchor: topLeftPoint(event))
         }
         cameraMoved()
     }

--- a/Sources/SpaceMatters/Views/TreemapView.swift
+++ b/Sources/SpaceMatters/Views/TreemapView.swift
@@ -427,10 +427,14 @@ final class TreemapNSView: NSView, CALayerDelegate {
         }
 
         if dataChanged {
-            // Scan tick / FSEvents refresh / metric change: entries revalidate
+            // FSEvents refresh / deletion / metric change: entries revalidate
             // lazily (ε-local), and whatever moved morphs (SPEC-10 §3.4). A pure
-            // theme change only recolours — no motion to animate.
-            rebuildTiles(morph: !themeChanged)
+            // theme change only recolours — no motion to animate. And a *live
+            // scan* teleports: it restructures violently at 10 Hz, so sliding
+            // tiles would never land — the map read as scattered squares over
+            // the root underlay. Instant rebuilds keep every frame a coherent
+            // tiling; the morphs come back for the calm post-scan life.
+            rebuildTiles(morph: !themeChanged && !controller.isScanning)
             presentTiles()
             overlayLayer.setNeedsDisplay()
         }

--- a/Sources/SpaceMatters/Views/TreemapWorld.swift
+++ b/Sources/SpaceMatters/Views/TreemapWorld.swift
@@ -1,0 +1,458 @@
+import CoreGraphics
+import Foundation
+
+// SPEC-10: the persistent treemap world. The layout is a pure function of the
+// tree — every node stores its children's rects *parent-relative, in the unit
+// square*, decided once and revalidated locally — and the viewport is only a
+// camera over it. Nothing here depends on the window: resize, pan and zoom are
+// camera moves; ticks of a live scan revalidate entries lazily (ε-stable local
+// moves) instead of re-rolling the whole tiling.
+
+/// The camera: a world-space viewport rect mapped onto the view. Anisotropic by
+/// design — at fit the viewport *is* the world rect, so the map fills the pane
+/// and any window/world aspect mismatch is a bounded stretch (re-baked away at
+/// the end of a resize, see `TreemapNSView`). View coordinates are top-left
+/// oriented points (the historical tile convention; CG flips happen at draw).
+struct WorldCamera: Equatable {
+    var rect: CGRect
+
+    /// Points per world unit on each axis for a given view size.
+    func scale(viewSize: CGSize) -> (sx: CGFloat, sy: CGFloat) {
+        (viewSize.width / max(rect.width, .leastNormalMagnitude),
+         viewSize.height / max(rect.height, .leastNormalMagnitude))
+    }
+
+    func viewToWorld(_ p: CGPoint, viewSize: CGSize) -> CGPoint {
+        CGPoint(x: rect.minX + p.x / viewSize.width * rect.width,
+                y: rect.minY + p.y / viewSize.height * rect.height)
+    }
+
+    func worldToView(_ r: CGRect, viewSize: CGSize) -> CGRect {
+        let (sx, sy) = scale(viewSize: viewSize)
+        return CGRect(x: (r.minX - rect.minX) * sx,
+                      y: (r.minY - rect.minY) * sy,
+                      width: r.width * sx,
+                      height: r.height * sy)
+    }
+
+    /// Zoom by `factor` (> 1 zooms in) keeping the world point under `anchorView`
+    /// fixed on screen — the Google Maps invariant.
+    mutating func zoom(by factor: CGFloat, anchorView: CGPoint, viewSize: CGSize) {
+        let anchor = viewToWorld(anchorView, viewSize: viewSize)
+        let f = 1 / factor
+        rect = CGRect(x: anchor.x - (anchor.x - rect.minX) * f,
+                      y: anchor.y - (anchor.y - rect.minY) * f,
+                      width: rect.width * f,
+                      height: rect.height * f)
+    }
+
+    /// Pan by a view-space delta (points).
+    mutating func pan(byView delta: CGSize, viewSize: CGSize) {
+        let (sx, sy) = scale(viewSize: viewSize)
+        rect.origin.x -= delta.width / sx
+        rect.origin.y -= delta.height / sy
+    }
+}
+
+@MainActor
+final class TreemapWorld {
+
+    /// A laid-out tile in absolute world coordinates (CGFloat is Double on macOS;
+    /// composition happens in full precision — the Float conversion is done
+    /// view-side, rebased on the camera).
+    struct Tile {
+        let rect: CGRect
+        let node: FSNode
+        let depth: Int
+        let isFileBlock: Bool
+        let file: FileTileInfo?
+    }
+
+    /// Identity of a tile across builds — what the morph pairs on.
+    struct TileKey: Hashable {
+        let id: ObjectIdentifier
+        let isFileBlock: Bool
+        let fileName: String?
+
+        init(_ tile: Tile) {
+            id = ObjectIdentifier(tile.node)
+            isFileBlock = tile.isFileBlock
+            fileName = tile.file?.name
+        }
+
+        init(id: ObjectIdentifier, isFileBlock: Bool, fileName: String?) {
+            self.id = id
+            self.isFileBlock = isFileBlock
+            self.fileName = fileName
+        }
+    }
+
+    struct BuildResult {
+        var tiles: [Tile] = []
+        var regions: [ObjectIdentifier: CGRect] = [:]
+        /// A file listing was requested but hasn't landed yet — the caller
+        /// schedules one follow-up rebuild to pick it up.
+        var pendingFiles = false
+    }
+
+    /// LOD thresholds, in projected screen points. `expandSide > collapseSide`
+    /// is the hysteresis that keeps tiles from popping at the boundary.
+    struct LOD {
+        var expandSide: CGFloat = 14
+        var collapseSide: CGFloat = 8
+        var filesSide: CGFloat = 400
+        var cullSide: CGFloat = 0.5
+        /// Safety rail against pathological trees; LOD, not this, is the driver.
+        var maxDepth: Int = 64
+    }
+
+    /// Fraction of the visible rect added on every side when building, so small
+    /// pans reuse the built set instead of rebuilding per frame.
+    static let buildMargin: CGFloat = 0.25
+
+    // MARK: World state
+
+    /// Abstract world rect: area is normalised (~1e6 units²), aspect follows the
+    /// window lazily (re-bake with hysteresis — never mid-drag).
+    private(set) var worldSize: CGSize
+
+    private var metric: SizeMetric
+    private var version: UInt64
+    private var rootID: ObjectIdentifier?
+
+    init(aspect: CGFloat = 1.6, metric: SizeMetric = .physical) {
+        self.worldSize = Self.size(forAspect: aspect)
+        self.metric = metric
+        self.version = 0
+    }
+
+    static func size(forAspect aspect: CGFloat) -> CGSize {
+        let a = min(max(aspect, 0.2), 5.0)
+        return CGSize(width: 1000 * sqrt(a), height: 1000 / sqrt(a))
+    }
+
+    var worldBounds: CGRect { CGRect(origin: .zero, size: worldSize) }
+    var aspect: CGFloat { worldSize.width / worldSize.height }
+
+    // MARK: Per-node entries (the world's persistent structure)
+
+    /// One node's children layout: items + weights (data half), squarify decisions
+    /// (discrete half) and parent-relative unit rects (continuous half).
+    private final class Entry {
+        var items: [TreemapLayout.Item]
+        var weights: [Double]
+        var breaks: [Int] = []
+        var orientations: [Bool] = []
+        /// Children rects relative to the node, in the unit square.
+        var unitRects: [CGRect] = []
+        /// Version this entry was last validated against (ε check).
+        var stamp: UInt64
+
+        init(items: [TreemapLayout.Item], weights: [Double], stamp: UInt64) {
+            self.items = items
+            self.weights = weights
+            self.stamp = stamp
+        }
+    }
+
+    private var entries: [ObjectIdentifier: Entry] = [:]
+    /// LOD hysteresis state: nodes currently expanded.
+    private var expanded: Set<ObjectIdentifier> = []
+    /// Weight drift (relative to the sibling total) below which an entry keeps
+    /// its discrete decisions and only re-flows geometry — the "local moves" ε.
+    static let epsilon = 0.02
+
+    // MARK: File-layout LRU (file LOD, generalising SPEC-05)
+
+    private struct FileLayout {
+        let count: Int64
+        let metric: SizeMetric
+        let files: [FileTileInfo]
+        let unitRects: [CGRect]
+    }
+    private var fileLayouts: [ObjectIdentifier: FileLayout] = [:]
+    private var fileLayoutOrder: [ObjectIdentifier] = []
+    private static let fileLayoutCap = 64
+
+    // MARK: Synchronisation with the data
+
+    /// Align the world with the current tree state. A metric or root change is a
+    /// new world (full reset); a version change only marks entries stale — they
+    /// revalidate lazily, locally, on their next visit (ε-stable).
+    func sync(root: FSNode, metric: SizeMetric, version: UInt64) {
+        let rid = ObjectIdentifier(root)
+        if rid != rootID || metric != self.metric {
+            entries.removeAll(keepingCapacity: true)
+            fileLayouts.removeAll(keepingCapacity: true)
+            fileLayoutOrder.removeAll(keepingCapacity: true)
+            if rid != rootID { expanded.removeAll(keepingCapacity: true) }
+            rootID = rid
+            self.metric = metric
+        }
+        self.version = version
+    }
+
+    /// Re-decide the whole world at a new aspect (end of a window resize beyond
+    /// the hysteresis band). The only global re-roll allowed — and it's animated.
+    func rebake(aspect: CGFloat) {
+        worldSize = Self.size(forAspect: aspect)
+        entries.removeAll(keepingCapacity: true)
+        fileLayouts.removeAll(keepingCapacity: true)
+        fileLayoutOrder.removeAll(keepingCapacity: true)
+    }
+
+    // MARK: Building (the LOD walk)
+
+    /// Produce the drawable tile set for the given camera. Only nodes intersecting
+    /// the (margin-inflated) visible rect are walked; expansion is decided on
+    /// projected size with hysteresis; entries build/revalidate lazily on visit.
+    func build(root: FSNode,
+               visible: CGRect,
+               scale: (sx: CGFloat, sy: CGFloat),
+               lod: LOD = LOD(),
+               needsRegions: Bool,
+               files: (FSNode) -> [FileTileInfo]?) -> BuildResult {
+        var result = BuildResult()
+        result.tiles.reserveCapacity(4096)
+        let inflated = visible.insetBy(dx: -visible.width * Self.buildMargin,
+                                       dy: -visible.height * Self.buildMargin)
+        walk(node: root, rect: worldBounds, depth: 0, inflated: inflated, scale: scale,
+             lod: lod, needsRegions: needsRegions, files: files, into: &result)
+        return result
+    }
+
+    private func walk(node: FSNode,
+                      rect: CGRect,
+                      depth: Int,
+                      inflated: CGRect,
+                      scale: (sx: CGFloat, sy: CGFloat),
+                      lod: LOD,
+                      needsRegions: Bool,
+                      files: (FSNode) -> [FileTileInfo]?,
+                      into result: inout BuildResult) {
+        guard rect.intersects(inflated) else { return }
+        let projMin = min(rect.width * scale.sx, rect.height * scale.sy)
+        guard projMin >= lod.cullSide else { return }
+        if needsRegions { result.regions[ObjectIdentifier(node)] = rect }
+
+        // Hysteresis: expand above expandSide, collapse below collapseSide,
+        // keep the previous state in between.
+        let id = ObjectIdentifier(node)
+        var expand: Bool
+        if depth >= lod.maxDepth {
+            expand = false
+        } else if projMin > lod.expandSide {
+            expand = true
+        } else if projMin < lod.collapseSide {
+            expand = false
+        } else {
+            expand = expanded.contains(id)
+        }
+        if depth == 0 { expand = true }   // the root is never an aggregate
+        if expand { expanded.insert(id) } else { expanded.remove(id) }
+
+        guard expand else {
+            result.tiles.append(Tile(rect: rect, node: node, depth: depth, isFileBlock: false, file: nil))
+            return
+        }
+
+        let entry = validatedEntry(for: node, rect: rect)
+        guard !entry.items.isEmpty else {
+            result.tiles.append(Tile(rect: rect, node: node, depth: depth, isFileBlock: false, file: nil))
+            return
+        }
+
+        for i in entry.items.indices {
+            let item = entry.items[i]
+            let u = entry.unitRects[i]
+            let r = CGRect(x: rect.minX + u.minX * rect.width,
+                           y: rect.minY + u.minY * rect.height,
+                           width: u.width * rect.width,
+                           height: u.height * rect.height)
+            guard r.intersects(inflated),
+                  min(r.width * scale.sx, r.height * scale.sy) >= lod.cullSide else { continue }
+            if item.isFileBlock {
+                emitFileBlock(node: node, rect: r, depth: depth + 1, scale: scale, lod: lod,
+                              files: files, into: &result)
+            } else {
+                walk(node: item.node, rect: r, depth: depth + 1, inflated: inflated, scale: scale,
+                     lod: lod, needsRegions: needsRegions, files: files, into: &result)
+            }
+        }
+    }
+
+    /// The node's own-files block: a single tile below `filesSide`, individual
+    /// file tiles above it (file LOD — SPEC-05 generalised to any folder big
+    /// enough on screen, laid out inside the block so directories stay put).
+    private func emitFileBlock(node: FSNode,
+                               rect: CGRect,
+                               depth: Int,
+                               scale: (sx: CGFloat, sy: CGFloat),
+                               lod: LOD,
+                               files: (FSNode) -> [FileTileInfo]?,
+                               into result: inout BuildResult) {
+        let projMin = min(rect.width * scale.sx, rect.height * scale.sy)
+        if projMin > lod.filesSide, let layout = fileLayout(for: node, files: files, pending: &result.pendingFiles) {
+            for i in layout.files.indices {
+                let u = layout.unitRects[i]
+                let r = CGRect(x: rect.minX + u.minX * rect.width,
+                               y: rect.minY + u.minY * rect.height,
+                               width: u.width * rect.width,
+                               height: u.height * rect.height)
+                guard min(r.width * scale.sx, r.height * scale.sy) >= lod.cullSide else { continue }
+                result.tiles.append(Tile(rect: r, node: node, depth: depth, isFileBlock: false, file: layout.files[i]))
+            }
+            return
+        }
+        result.tiles.append(Tile(rect: rect, node: node, depth: depth, isFileBlock: true, file: nil))
+    }
+
+    private func fileLayout(for node: FSNode,
+                            files: (FSNode) -> [FileTileInfo]?,
+                            pending: inout Bool) -> FileLayout? {
+        let id = ObjectIdentifier(node)
+        let count = node.directFileCount
+        if let cached = fileLayouts[id], cached.count == count, cached.metric == metric {
+            return cached.files.isEmpty ? nil : cached
+        }
+        guard let listing = files(node) else {
+            pending = true                 // in flight — caller re-builds when it lands
+            return nil
+        }
+        let sorted = listing.filter { $0.size > 0 }.sorted { $0.size > $1.size }
+        let weights = sorted.map { Double($0.size) }
+        let unit = CGRect(x: 0, y: 0, width: 1, height: 1)
+        let layout = FileLayout(count: count, metric: metric, files: sorted,
+                                unitRects: TreemapLayout.squarifySorted(weights, into: unit))
+        fileLayouts[id] = layout
+        fileLayoutOrder.removeAll { $0 == id }
+        fileLayoutOrder.append(id)
+        if fileLayoutOrder.count > Self.fileLayoutCap {
+            fileLayouts.removeValue(forKey: fileLayoutOrder.removeFirst())
+        }
+        return layout.files.isEmpty ? nil : layout
+    }
+
+    // MARK: Entries — lazy build + ε-stable revalidation ("local moves")
+
+    private func validatedEntry(for node: FSNode, rect: CGRect) -> Entry {
+        let id = ObjectIdentifier(node)
+        if let entry = entries[id] {
+            if entry.stamp != version { revalidate(entry, node: node, rect: rect) }
+            return entry
+        }
+        let built = TreemapLayout.buildItems(node: node, depth: 1, metric: metric, files: nil)
+        let entry = Entry(items: built.items, weights: built.weights, stamp: version)
+        decide(entry, rect: rect)
+        entries[id] = entry
+        return entry
+    }
+
+    /// The version moved under this entry: rebuild its items and compare. Same
+    /// children with weights within ε → keep the discrete decisions, re-flow the
+    /// continuous geometry only (bit-stable structure, exact areas). Otherwise
+    /// re-decide this node alone — a local move, animated by the caller's morph.
+    private func revalidate(_ entry: Entry, node: FSNode, rect: CGRect) {
+        let built = TreemapLayout.buildItems(node: node, depth: 1, metric: metric, files: nil)
+        defer { entry.stamp = version }
+        let sameSet = built.items.count == entry.items.count && zip(built.items, entry.items).allSatisfy {
+            $0.node === $1.node && $0.isFileBlock == $1.isFileBlock
+        }
+        if sameSet {
+            let newTotal = built.weights.reduce(0, +)
+            let oldTotal = entry.weights.reduce(0, +)
+            if newTotal > 0, oldTotal > 0 {
+                var maxDrift = 0.0
+                for i in built.weights.indices {
+                    let drift = abs(built.weights[i] / newTotal - entry.weights[i] / oldTotal)
+                    if drift > maxDrift { maxDrift = drift }
+                }
+                if maxDrift <= Self.epsilon {
+                    // Continuous-only refresh: same rows, exact new areas.
+                    entry.items = built.items
+                    entry.weights = built.weights
+                    place(entry, rect: rect)
+                    return
+                }
+            }
+        }
+        entry.items = built.items
+        entry.weights = built.weights
+        decide(entry, rect: rect)
+    }
+
+    /// Decide rows at this node's *world aspect* (scale-invariant) and derive the
+    /// parent-relative unit rects.
+    private func decide(_ entry: Entry, rect: CGRect) {
+        let decided = TreemapLayout.decideRows(entry.weights, rect: CGRect(origin: .zero, size: rect.size))
+        entry.breaks = decided.breaks
+        entry.orientations = decided.orientations
+        place(entry, rect: rect)
+    }
+
+    private func place(_ entry: Entry, rect: CGRect) {
+        let placed = TreemapLayout.placeRows(entry.weights,
+                                             rect: CGRect(origin: .zero, size: rect.size),
+                                             breaks: entry.breaks,
+                                             orientations: entry.orientations)
+        let w = max(rect.width, .leastNormalMagnitude)
+        let h = max(rect.height, .leastNormalMagnitude)
+        entry.unitRects = placed.map {
+            CGRect(x: $0.minX / w, y: $0.minY / h, width: $0.width / w, height: $0.height / h)
+        }
+    }
+
+    // MARK: World queries
+
+    /// Absolute world rect of a node: compose the parent-relative rects down the
+    /// ancestor chain (entries build on demand along the path). `nil` when the
+    /// node isn't reachable from the root (e.g. freed subtree mid-refresh).
+    func worldRect(of node: FSNode, root: FSNode) -> CGRect? {
+        var chain: [FSNode] = []
+        var cur: FSNode? = node
+        while let n = cur, n !== root { chain.append(n); cur = n.parent }
+        guard cur === root else { return nil }
+        var rect = worldBounds
+        for child in chain.reversed() {
+            let entry = validatedEntry(for: child.parent ?? root, rect: rect)
+            guard let i = entry.items.firstIndex(where: { $0.node === child && !$0.isFileBlock && $0.file == nil })
+            else { return nil }
+            let u = entry.unitRects[i]
+            rect = CGRect(x: rect.minX + u.minX * rect.width,
+                          y: rect.minY + u.minY * rect.height,
+                          width: u.width * rect.width,
+                          height: u.height * rect.height)
+        }
+        return rect
+    }
+
+    /// The deepest directory whose world rect contains the visible rect — what the
+    /// breadcrumb/list follow while the camera moves (`zoomRoot` as a derived value).
+    func focusNode(root: FSNode, visible: CGRect) -> FSNode {
+        var node = root
+        var rect = worldBounds
+        var depth = 0
+        while depth < 64 {
+            let entry = validatedEntry(for: node, rect: rect)
+            var descended = false
+            for i in entry.items.indices {
+                let item = entry.items[i]
+                guard !item.isFileBlock, item.file == nil, item.node.isDirectory else { continue }
+                let u = entry.unitRects[i]
+                let r = CGRect(x: rect.minX + u.minX * rect.width,
+                               y: rect.minY + u.minY * rect.height,
+                               width: u.width * rect.width,
+                               height: u.height * rect.height)
+                if r.contains(visible) {
+                    node = item.node
+                    rect = r
+                    depth += 1
+                    descended = true
+                    break
+                }
+            }
+            if !descended { break }
+        }
+        return node
+    }
+}

--- a/Sources/SpaceMatters/Views/TreemapWorld.swift
+++ b/Sources/SpaceMatters/Views/TreemapWorld.swift
@@ -262,6 +262,13 @@ final class TreemapWorld {
             return
         }
 
+        // Underlay: the expanded node's own tile, painted *under* its children
+        // (painter's order — children come later in the list). Children culled
+        // below `cullSide` then show the folder's colour instead of punching a
+        // hole to the background — a folder of thousands of sub-pixel children
+        // used to read as a black rectangle.
+        result.tiles.append(Tile(rect: rect, node: node, depth: depth, isFileBlock: false, file: nil))
+
         for i in entry.items.indices {
             let item = entry.items[i]
             let u = entry.unitRects[i]
@@ -293,6 +300,8 @@ final class TreemapWorld {
                                into result: inout BuildResult) {
         let projMin = min(rect.width * scale.sx, rect.height * scale.sy)
         if projMin > lod.filesSide, let layout = fileLayout(for: node, files: files, pending: &result.pendingFiles) {
+            // Underlay (see `walk`): culled tiny files show the block, not a hole.
+            result.tiles.append(Tile(rect: rect, node: node, depth: depth, isFileBlock: true, file: nil))
             for i in layout.files.indices {
                 let u = layout.unitRects[i]
                 let r = CGRect(x: rect.minX + u.minX * rect.width,

--- a/Sources/SpaceMatters/Views/TreemapWorld.swift
+++ b/Sources/SpaceMatters/Views/TreemapWorld.swift
@@ -147,6 +147,12 @@ final class TreemapWorld {
         var unitRects: [CGRect] = []
         /// Version this entry was last validated against (ε check).
         var stamp: UInt64
+        /// Snapshot at *decision* time: weight shares and the node's rect aspect.
+        /// Drift is measured against these — not the last revalidation — so many
+        /// small steps can't walk the tiling arbitrarily far from the shape it
+        /// was decided for (the cumulative-drift source of sliver tiles).
+        var decisionShares: [Double] = []
+        var decisionAspect: CGFloat = 1
 
         init(items: [TreemapLayout.Item], weights: [Double], stamp: UInt64) {
             self.items = items
@@ -357,31 +363,35 @@ final class TreemapWorld {
         return entry
     }
 
-    /// The version moved under this entry: rebuild its items and compare. Same
-    /// children with weights within ε → keep the discrete decisions, re-flow the
-    /// continuous geometry only (bit-stable structure, exact areas). Otherwise
-    /// re-decide this node alone — a local move, animated by the caller's morph.
+    /// The version moved under this entry: rebuild its items and compare against
+    /// the *decision-time* snapshot. Same children, shares within ε of the decided
+    /// shares, node aspect near the decided aspect, and a placement that still
+    /// looks good → keep the discrete decisions and re-flow the continuous
+    /// geometry only (bit-stable structure, exact areas). Otherwise re-decide
+    /// this node alone — a local move, animated by the caller's morph.
     private func revalidate(_ entry: Entry, node: FSNode, rect: CGRect) {
         let built = TreemapLayout.buildItems(node: node, depth: 1, metric: metric, files: nil)
         defer { entry.stamp = version }
         let sameSet = built.items.count == entry.items.count && zip(built.items, entry.items).allSatisfy {
             $0.node === $1.node && $0.isFileBlock == $1.isFileBlock
         }
-        if sameSet {
+        if sameSet, entry.decisionShares.count == built.weights.count {
             let newTotal = built.weights.reduce(0, +)
-            let oldTotal = entry.weights.reduce(0, +)
-            if newTotal > 0, oldTotal > 0 {
+            if newTotal > 0 {
                 var maxDrift = 0.0
                 for i in built.weights.indices {
-                    let drift = abs(built.weights[i] / newTotal - entry.weights[i] / oldTotal)
+                    let drift = abs(built.weights[i] / newTotal - entry.decisionShares[i])
                     if drift > maxDrift { maxDrift = drift }
                 }
-                if maxDrift <= Self.epsilon {
-                    // Continuous-only refresh: same rows, exact new areas.
+                let aspect = rect.height > 0 ? rect.width / rect.height : 1
+                let aspectDrift = aspect / max(entry.decisionAspect, .leastNormalMagnitude)
+                if maxDrift <= Self.epsilon, aspectDrift > 0.8, aspectDrift < 1.25 {
+                    // Continuous-only refresh: same rows, exact new areas — kept
+                    // only while the result still reads as a squarified map.
                     entry.items = built.items
                     entry.weights = built.weights
                     place(entry, rect: rect)
-                    return
+                    if worstTileAspect(entry, rect: rect) <= Self.aspectQualityLimit { return }
                 }
             }
         }
@@ -390,13 +400,31 @@ final class TreemapWorld {
         decide(entry, rect: rect)
     }
 
-    /// Decide rows at this node's *world aspect* (scale-invariant) and derive the
-    /// parent-relative unit rects.
+    /// Decide rows at this node's *world aspect* (scale-invariant), derive the
+    /// parent-relative unit rects, and snapshot the decision context (ε baseline).
     private func decide(_ entry: Entry, rect: CGRect) {
         let decided = TreemapLayout.decideRows(entry.weights, rect: CGRect(origin: .zero, size: rect.size))
         entry.breaks = decided.breaks
         entry.orientations = decided.orientations
+        let total = entry.weights.reduce(0, +)
+        entry.decisionShares = total > 0 ? entry.weights.map { $0 / total } : []
+        entry.decisionAspect = rect.height > 0 ? rect.width / rect.height : 1
         place(entry, rect: rect)
+    }
+
+    /// Sliver guard: worst width/height ratio the unit rects produce at this
+    /// node's aspect. Above `aspectQualityLimit` the kept decisions are stale
+    /// enough to hurt (long thin tiles — ugly and barely clickable): re-decide.
+    static let aspectQualityLimit: CGFloat = 5
+    private func worstTileAspect(_ entry: Entry, rect: CGRect) -> CGFloat {
+        var worst: CGFloat = 1
+        for u in entry.unitRects {
+            let w = u.width * rect.width
+            let h = u.height * rect.height
+            guard w > 0, h > 0 else { continue }
+            worst = max(worst, max(w / h, h / w))
+        }
+        return worst
     }
 
     private func place(_ entry: Entry, rect: CGRect) {

--- a/Tests/SpaceMattersTests/TreemapWorldTests.swift
+++ b/Tests/SpaceMattersTests/TreemapWorldTests.swift
@@ -1,0 +1,197 @@
+import Testing
+import Foundation
+@testable import SpaceMatters
+
+/// SPEC-10 property tests: the world's geometry is a pure function of the data
+/// (the camera never changes it), entries revalidate ε-locally under version
+/// bumps, LOD expansion follows projected size with hysteresis, and the camera
+/// math holds its invariants (anchor-fixed zoom, view↔world roundtrip).
+@MainActor
+@Suite struct TreemapWorldTests {
+
+    /// root ── a (600) / b (300) / 100 B of direct files.
+    private func makeTree() -> (root: FSNode, a: FSNode, b: FSNode) {
+        let root = FSNode(name: "root", parent: nil)
+        let a = FSNode(name: "a", parent: root)
+        let b = FSNode(name: "b", parent: root)
+        a.finishScan(children: [], filesLogical: 600, filesPhysical: 600, fileCount: 6)
+        a.aggPhysical.store(600, ordering: .relaxed)
+        a.aggLogical.store(600, ordering: .relaxed)
+        b.finishScan(children: [], filesLogical: 300, filesPhysical: 300, fileCount: 3)
+        b.aggPhysical.store(300, ordering: .relaxed)
+        b.aggLogical.store(300, ordering: .relaxed)
+        root.finishScan(children: [a, b], filesLogical: 100, filesPhysical: 100, fileCount: 2)
+        root.aggPhysical.store(1000, ordering: .relaxed)
+        root.aggLogical.store(1000, ordering: .relaxed)
+        return (root, a, b)
+    }
+
+    private func build(_ world: TreemapWorld, root: FSNode,
+                       scale: CGFloat = 1,
+                       visible: CGRect? = nil) -> TreemapWorld.BuildResult {
+        world.build(root: root, visible: visible ?? world.worldBounds,
+                    scale: (sx: scale, sy: scale), needsRegions: true, files: { _ in [] })
+    }
+
+    // The world is viewport-independent: two builds with different cameras give
+    // identical rects for the tiles they share — the anti-"re-roll" guarantee.
+    @Test func cameraNeverMovesTheWorld() {
+        let (root, a, _) = makeTree()
+        let world = TreemapWorld()
+        world.sync(root: root, metric: .physical, version: 1)
+
+        let full = build(world, root: root, scale: 1)
+        let zoomedVisible = CGRect(x: 0, y: 0,
+                                   width: world.worldSize.width / 4,
+                                   height: world.worldSize.height / 4)
+        let zoomed = build(world, root: root, scale: 8, visible: zoomedVisible)
+
+        let rectsFull = Dictionary(uniqueKeysWithValues: full.tiles.map { (TreemapWorld.TileKey($0), $0.rect) })
+        for tile in zoomed.tiles {
+            if let r = rectsFull[TreemapWorld.TileKey(tile)] {
+                #expect(abs(r.minX - tile.rect.minX) < 1e-9)
+                #expect(abs(r.width - tile.rect.width) < 1e-9)
+            }
+        }
+        // worldRect(of:) composes to the same geometry the build emits.
+        let aRect = world.worldRect(of: a, root: root)
+        let aRegion = full.regions[ObjectIdentifier(a)]
+        #expect(aRect != nil && aRegion != nil)
+        if let aRect, let aRegion {
+            #expect(abs(aRect.minX - aRegion.minX) < 1e-9)
+            #expect(abs(aRect.width - aRegion.width) < 1e-9)
+        }
+    }
+
+    // ε-revalidation: a version bump with a small weight drift keeps the discrete
+    // structure — tiles stay where they were (bounded slide, no re-roll).
+    @Test func smallDriftKeepsTheTiling() {
+        let (root, a, _) = makeTree()
+        let world = TreemapWorld()
+        world.sync(root: root, metric: .physical, version: 1)
+        let before = build(world, root: root, scale: 1)
+
+        // +1 % on `a` — well under ε.
+        a.aggPhysical.store(606, ordering: .relaxed)
+        root.aggPhysical.store(1006, ordering: .relaxed)
+        world.sync(root: root, metric: .physical, version: 2)
+        let after = build(world, root: root, scale: 1)
+
+        #expect(after.tiles.count == before.tiles.count)
+        let rectsBefore = Dictionary(uniqueKeysWithValues: before.tiles.map { (TreemapWorld.TileKey($0), $0.rect) })
+        let slack = world.worldSize.width * 0.05
+        for tile in after.tiles {
+            guard let r = rectsBefore[TreemapWorld.TileKey(tile)] else { continue }
+            #expect(abs(r.minX - tile.rect.minX) < slack)
+            #expect(abs(r.minY - tile.rect.minY) < slack)
+        }
+    }
+
+    // LOD: a scale too small to matter aggregates children; zooming in expands
+    // them; sitting back in the hysteresis band keeps the expansion.
+    @Test func lodExpansionFollowsProjectedSizeWithHysteresis() {
+        let (root, _, _) = makeTree()
+        let world = TreemapWorld()
+        world.sync(root: root, metric: .physical, version: 1)
+
+        // Children project far below collapseSide → root renders as its children?
+        // No: the *root* is always expanded, its children aggregate.
+        let coarse = build(world, root: root, scale: 0.005)
+        #expect(coarse.tiles.count <= 3)
+        #expect(coarse.tiles.allSatisfy { $0.file == nil })
+
+        // At scale 1 the children are hundreds of points wide → expanded (here
+        // they're leaves, so they stay single tiles — but regions carry them).
+        let fine = build(world, root: root, scale: 1)
+        #expect(fine.regions[ObjectIdentifier(root)] != nil)
+
+        // Hysteresis: expansion state persists inside the band. Build at an
+        // in-between scale twice; the expanded set must not flap.
+        let mid1 = build(world, root: root, scale: 0.011)
+        let mid2 = build(world, root: root, scale: 0.011)
+        #expect(mid1.tiles.count == mid2.tiles.count)
+    }
+
+    // File LOD: once a folder's file block projects large enough, its files
+    // become individual tiles laid out inside the block.
+    @Test func fileBlockRefinesAtFileLODThreshold() {
+        let (root, _, _) = makeTree()
+        let world = TreemapWorld()
+        world.sync(root: root, metric: .physical, version: 1)
+
+        let files = [
+            FileTileInfo(name: "big.bin", size: 70, extName: ".bin"),
+            FileTileInfo(name: "small.bin", size: 30, extName: ".bin"),
+        ]
+        // Only the root's listing resolves; the leaf folders stay aggregate blocks.
+        let result = world.build(root: root, visible: world.worldBounds,
+                                 scale: (sx: 50, sy: 50), needsRegions: false,
+                                 files: { node in node === root ? files : [] })
+        let fileTiles = result.tiles.filter { $0.file != nil }
+        #expect(fileTiles.count == 2)
+        // File tiles partition their block: no overlap.
+        if fileTiles.count == 2 {
+            #expect(!fileTiles[0].rect.insetBy(dx: 1e-6, dy: 1e-6).intersects(fileTiles[1].rect))
+        }
+
+        // A pending listing (nil) keeps the aggregate block and flags the build
+        // so the view schedules a follow-up once the listing lands.
+        let freshWorld = TreemapWorld()
+        freshWorld.sync(root: root, metric: .physical, version: 1)
+        let pending = freshWorld.build(root: root, visible: freshWorld.worldBounds,
+                                       scale: (sx: 50, sy: 50), needsRegions: false,
+                                       files: { _ in nil })
+        #expect(pending.pendingFiles)
+        #expect(pending.tiles.contains { $0.isFileBlock })
+    }
+
+    // focusNode derives the deepest folder containing the viewport.
+    @Test func focusNodeFollowsTheCamera() {
+        let (root, a, _) = makeTree()
+        let world = TreemapWorld()
+        world.sync(root: root, metric: .physical, version: 1)
+        _ = build(world, root: root, scale: 1)
+
+        #expect(world.focusNode(root: root, visible: world.worldBounds) === root)
+        if let aRect = world.worldRect(of: a, root: root) {
+            let inside = aRect.insetBy(dx: aRect.width * 0.2, dy: aRect.height * 0.2)
+            #expect(world.focusNode(root: root, visible: inside) === a)
+        }
+    }
+
+    // Camera invariants: view↔world roundtrip, and zoom keeps the anchor fixed.
+    @Test func cameraMathHoldsItsInvariants() {
+        var cam = WorldCamera(rect: CGRect(x: 100, y: 50, width: 800, height: 500))
+        let viewSize = CGSize(width: 400, height: 250)
+
+        let p = CGPoint(x: 123, y: 77)
+        let w = cam.viewToWorld(p, viewSize: viewSize)
+        let back = cam.worldToView(CGRect(origin: w, size: .zero), viewSize: viewSize)
+        #expect(abs(back.origin.x - p.x) < 1e-9)
+        #expect(abs(back.origin.y - p.y) < 1e-9)
+
+        let anchorWorldBefore = cam.viewToWorld(p, viewSize: viewSize)
+        cam.zoom(by: 2.5, anchorView: p, viewSize: viewSize)
+        let anchorWorldAfter = cam.viewToWorld(p, viewSize: viewSize)
+        #expect(abs(anchorWorldBefore.x - anchorWorldAfter.x) < 1e-9)
+        #expect(abs(anchorWorldBefore.y - anchorWorldAfter.y) < 1e-9)
+        #expect(abs(cam.rect.width - 800 / 2.5) < 1e-9)
+    }
+
+    // Deep-zoom precision: a viewport a millionth of the world still roundtrips
+    // exactly in Double (the Float conversion is camera-rebased view-side).
+    @Test func deepZoomPrecisionHolds() {
+        let world = TreemapWorld()
+        let tiny = CGRect(x: world.worldSize.width * 0.7,
+                          y: world.worldSize.height * 0.3,
+                          width: world.worldSize.width / 1_000_000,
+                          height: world.worldSize.height / 1_000_000)
+        let cam = WorldCamera(rect: tiny)
+        let viewSize = CGSize(width: 1000, height: 700)
+        let p = CGPoint(x: 500, y: 350)
+        let w = cam.viewToWorld(p, viewSize: viewSize)
+        let back = cam.worldToView(CGRect(origin: w, size: .zero), viewSize: viewSize)
+        #expect(abs(back.origin.x - p.x) < 1e-6)
+        #expect(abs(back.origin.y - p.y) < 1e-6)
+    }
+}

--- a/Tests/SpaceMattersTests/TreemapWorldTests.swift
+++ b/Tests/SpaceMattersTests/TreemapWorldTests.swift
@@ -147,6 +147,45 @@ import Foundation
         #expect(pending.tiles.contains { $0.isFileBlock })
     }
 
+    // Cumulative drift can't produce slivers: many small weight steps (each a
+    // few % — under ε per tick against the *last* baseline, which is exactly how
+    // stale decisions used to walk away) end up re-decided, keeping the worst
+    // tile aspect bounded by the quality guard.
+    @Test func cumulativeDriftKeepsTilesSquarish() {
+        let root = FSNode(name: "root", parent: nil)
+        var kids: [FSNode] = []
+        var sizes: [Int64] = [600, 500, 400, 300, 200, 100]
+        for (i, s) in sizes.enumerated() {
+            let k = FSNode(name: "k\(i)", parent: root)
+            k.finishScan(children: [], filesLogical: s, filesPhysical: s, fileCount: 1)
+            k.aggPhysical.store(s, ordering: .relaxed)
+            kids.append(k)
+        }
+        root.finishScan(children: kids, filesLogical: 0, filesPhysical: 0, fileCount: 0)
+        root.aggPhysical.store(sizes.reduce(0, +), ordering: .relaxed)
+
+        let world = TreemapWorld()
+        world.sync(root: root, metric: .physical, version: 1)
+        _ = build(world, root: root, scale: 1)
+
+        // 40 ticks: the biggest child triples gradually (~3 % of total per step,
+        // ranking preserved) — the shares walk far from the decided ones.
+        for step in 1...40 {
+            sizes[0] = 600 + Int64(step) * 30
+            kids[0].aggPhysical.store(sizes[0], ordering: .relaxed)
+            root.aggPhysical.store(sizes.reduce(0, +), ordering: .relaxed)
+            world.sync(root: root, metric: .physical, version: UInt64(1 + step))
+            let result = build(world, root: root, scale: 1)
+            var worst: CGFloat = 1
+            for tile in result.tiles where tile.node !== root {
+                guard tile.rect.width > 0, tile.rect.height > 0 else { continue }
+                worst = max(worst, max(tile.rect.width / tile.rect.height,
+                                       tile.rect.height / tile.rect.width))
+            }
+            #expect(worst <= TreemapWorld.aspectQualityLimit + 0.5, "worst aspect \(worst) at step \(step)")
+        }
+    }
+
     // focusNode derives the deepest folder containing the viewport.
     @Test func focusNodeFollowsTheCamera() {
         let (root, a, _) = makeTree()

--- a/Tests/SpaceMattersTests/TreemapWorldTests.swift
+++ b/Tests/SpaceMattersTests/TreemapWorldTests.swift
@@ -94,11 +94,13 @@ import Foundation
         let world = TreemapWorld()
         world.sync(root: root, metric: .physical, version: 1)
 
-        // Children project far below collapseSide → root renders as its children?
-        // No: the *root* is always expanded, its children aggregate.
+        // Children project far below collapseSide → the root (always expanded)
+        // renders its underlay + aggregated children, nothing deeper.
         let coarse = build(world, root: root, scale: 0.005)
-        #expect(coarse.tiles.count <= 3)
+        #expect(coarse.tiles.count <= 4)
         #expect(coarse.tiles.allSatisfy { $0.file == nil })
+        // The underlay comes first — children paint over it.
+        #expect(coarse.tiles.first?.node === root)
 
         // At scale 1 the children are hundreds of points wide → expanded (here
         // they're leaves, so they stay single tiles — but regions carry them).

--- a/specs/SPEC-10-world-treemap.md
+++ b/specs/SPEC-10-world-treemap.md
@@ -96,3 +96,15 @@ L'invalidation `version` cesse d'être globale : le scanner/FSEvents connaissent
 
 **Fait** : le paradigme monde (layout = données), caméra continue pan/zoom, LOD hiérarchique projeté (dossiers **et** fichiers), morphs sur tout changement, streaming sous scan, stabilité spatiale garantie et testée.
 **Ne fait PAS** : la 3D (hauteurs, perspective, orbite) — mais ce modèle en est le **prérequis propre** : SPEC-09 §9 s'active ensuite par caméra + hauteur sur un monde inchangé, le LOD et le morph s'appliquant tels quels aux boîtes. Pas de minimap (nice-to-have, à cadrer après M2). Pas de refonte du chrome SwiftUI (les 78 % du profil resize-fenêtre — chantier séparé). Le look des tuiles (palette, cushion, gouttières) ne change pas.
+
+## 9. Addendum post-implémentation (PR #25 — QA visuelle du 2026-07-12)
+
+Amendements actés pendant l'implémentation, après quatre passes de QA visuelle sur un scan réel (4 M fichiers) :
+
+- **§3.6 pooling du drawable : abandonné.** Le 🔬 s'est confirmé — le crop `contentsRect` produit des bandes noires pendant le drag. Le repli documenté s'applique : `drawableSize` exact par frame ; le resize étant devenu caméra-only, la réallocation d'IOSurface est le seul coût résiduel, assumé.
+- **§3.4 morph de subdivision : « appear-in-place », pas grow-from-parent.** La croissance géométrique depuis le rect parent superpose les enfants entre eux et sur leurs voisins pendant la transition (gros carrés fantômes au zoom). Les tuiles nouvelles apparaissent à leur place finale ; seules les tuiles présentes dans les deux builds glissent, et leurs **couleurs cross-fadent** (la renormalisation de luminosité fond au lieu de sauter). Un rebuild en plein morph repart de l'état affiché (lerp à t), pas de la cible précédente.
+- **§3.4 scan vivant : téléportation, pas morph.** À 10 Hz de restructurations violentes, des glissades de 220 ms n'atterrissent jamais — la carte se délite en carrés épars sur la sous-couche. Un scan actif rebuild instantanément (chaque frame est un pavage cohérent) ; les morphs s'appliquent à la vie calme post-scan (FSEvents, suppressions, métrique, re-bake d'aspect, LOD).
+- **§3.5 ε ancré aux parts de décision + garde de qualité.** La dérive mesurée contre la dernière revalidation (baseline glissante) laissait les décisions dériver sans borne par petits pas (lamelles 10:1). L'ε se mesure contre les parts **au moment de la décision**, la dérive d'aspect du rect du nœud (±25 %) re-décide aussi, et une garde auto-réparante re-décide localement au-delà d'un pire ratio de 5:1.
+- **Sous-couche parent** : chaque dossier développé (et bloc fichiers subdivisé) est peint sous ses enfants — les enfants cullés (< 0,5 px) montrent la couleur du dossier au lieu de percer un trou vers le fond ; hover/clic y tombent sur le dossier.
+- **Molette normalisée** : deltas précis ÷12, facteur borné à [0.5, 2] par événement (×1.15/cran, aligné sur le pincement).
+- Les tuiles disparues sont retirées sans fondu (le fondu à zéro impliquerait du blending — pipeline opaque conservé).

--- a/specs/SPEC-10-world-treemap.md
+++ b/specs/SPEC-10-world-treemap.md
@@ -1,0 +1,98 @@
+# SPEC-10 — Treemap-monde persistant : caméra continue, LOD hiérarchique, navigation « carte »
+
+> **Findings** : profilage resize du 2026-07-12 (Instruments, Game Performance, build release, M4 Pro) — pendant un live-drag : **main thread saturé à ~80 %**, **~16 ms CPU par frame présentée** (budget 120 Hz : 8,3 ms) → ~50 fps effectifs avec hitches à 25-46 ms. Répartition : **~22 % code app** (layout continu ~10 %, reconstruction `tiles`/repack ~6 %, présent ~4 % — dont création d'**IOSurface à chaque frame**, le `drawableSize` changeant invalide le pool de drawables), **~78 % machinerie AppKit/SwiftUI** (layout du chrome, contraintes, AttributeGraph — deux passes par frame). GPU : **0,3 %** d'utilisation, p50 0,13 ms — totalement désœuvré.
+> **Défaut de paradigme constaté** (captures à deux tailles de fenêtre) : le layout est une **fonction du viewport**. Le gel des décisions discrètes ([TreemapLayout.Cache](../Sources/SpaceMatters/Views/TreemapLayout.swift#L57)) rend le resize *monotone*, mais le cache est invalidé à chaque bump de `version` (tick de scan à 10 Hz, refresh FSEvents) et les décisions sont re-décidées **au rect courant de la fenêtre** — deux invalidations à deux tailles → deux mondes sans rapport, les gros blocs changent de place. Le « monde » est re-roulé en permanence.
+> **Décision d'architecture (proposée)** : inverser le paradigme, à la manière d'un moteur de jeu open-world — **le layout est une fonction pure des données, calculée en coordonnées monde ; le viewport n'est qu'une caméra ; le niveau de détail est une décision de rendu ; les changements de données sont des retouches locales animées, jamais un re-roll global.** En prime produit : le treemap devient **navigable façon Google Maps** (pan au trackpad, zoom continu vers le curseur, le détail qui se révèle en zoomant).
+> **Prérequis** : PR #24 (renderer Metal seul chemin de rendu, [Camera.ortho](../Sources/SpaceMatters/Views/TreemapMetalRenderer.swift#L39) découplant déjà viewport et instances).
+> **Statut** : 📋 **PROPOSÉ** — à planifier. Remplace la mécanique de « référence gelée » de SPEC-09/PR #17 par un modèle monde ; généralise SPEC-05 ; prépare l'activation 3D de SPEC-09 §9.
+
+## 1. Objectif
+
+Que plus **aucune** interaction caméra (resize de fenêtre, pan, zoom) ne recalcule ni ne re-packe quoi que ce soit : une frame caméra = une matrice, budget **< 1 ms** CPU main thread. Que la **position d'un dossier dans le monde soit stable** — entre deux resizes, entre deux ticks de scan, entre deux refreshes — et que tout changement structurel légitime (données qui bougent, aspect qui dérive trop) soit une **transition animée locale**, pas une téléportation globale. Et ouvrir la feature produit : **naviguer le disque comme une carte** — deux doigts pour se déplacer, pincer pour plonger, le niveau de détail qui suit.
+
+## 2. État actuel du code (vérifié)
+
+Ce qui existe et sur quoi on s'appuie :
+
+- **La caméra existe déjà** : [Camera.ortho(viewport:)](../Sources/SpaceMatters/Views/TreemapMetalRenderer.swift#L39) projette un rect-monde arbitraire sur le drawable ; l'animation de zoom ([startZoomAnimation](../Sources/SpaceMatters/Views/TreemapView.swift#L679)) anime déjà une caméra **sur des instances figées** — la preuve de concept du modèle est dans le code.
+- **Le gel partiel existe** : [TreemapLayout.Cache](../Sources/SpaceMatters/Views/TreemapLayout.swift#L57) mémoïse par nœud les décisions discrètes (breaks de rangées, orientations) et ne rejoue que la géométrie continue. Défauts : invalidation globale par `(metric, version, root)` ([ScanController.treemapLayout](../Sources/SpaceMatters/ViewModel/ScanController.swift#L540)), référence = rect fenêtre du moment, et la géométrie continue + [relayout()](../Sources/SpaceMatters/Views/TreemapView.swift#L399) + [packInstances](../Sources/SpaceMatters/Views/TreemapView.swift#L442) retournent **à chaque frame** de resize.
+- **Le renderer copie les instances à chaque render()** (triple buffer) — pas de chemin « caméra seule, buffer inchangé ».
+- **L'overlay CG ne sait pas suivre la caméra** (masqué pendant le zoom animé, hover désactivé pendant l'animation) ; le hit-test ([tileAt](../Sources/SpaceMatters/Views/TreemapView.swift#L599)) est en coordonnées vue, valide seulement caméra à l'identité.
+- **SPEC-05** : les fichiers du seul zoom root sont des tuiles ([filesIn](../Sources/SpaceMatters/ViewModel/ScanController.swift#L562), `rootFileTiles` mémoïsé) ; la navigation est un **état structurel** `zoomRoot` ([zoom(into:)](../Sources/SpaceMatters/ViewModel/ScanController.swift#L1150)) qui re-layoute.
+- Échelle : scan hôte type = **713 695 dossiers / 3,9 M fichiers** (capture du jour) ; profondeur possible > 20 niveaux.
+
+## 3. Conception retenue
+
+### 3.1 Le monde : coordonnées hiérarchiques parent-relatives
+Chaque nœud stocke son rect **relatif au parent, dans [0,1]²** (Float32, 16 o), décidé par le squarify sur les poids des enfants — **jamais en pixels, jamais fonction de la fenêtre**. Le rect-monde absolu d'un nœud est la **composition** des rects relatifs de sa lignée, calculée en `Double` au moment du rendu pour les seuls sous-arbres visibles. Propriétés :
+
+- **Stabilité par construction** : le rect relatif d'un nœud ne change que si les poids de sa fratrie changent — pas au resize, pas au zoom, pas quand un cousin lointain bouge.
+- **Précision** : à 4 M de fichiers, une tuile profonde peut mesurer 10⁻⁶ du monde ; composer en Double puis **re-baser caméra** (coordonnées caméra-relatives avant conversion Float pour le GPU — le *floating origin* des moteurs de jeu) élimine la casse de précision Float32 en zoom profond.
+- **Rangement** : extension de `Cache.Entry` (les entrées par nœud existent déjà) — pas de champ ajouté à `FSNode`, le modèle reste pur. Entrées construites **paresseusement** (seulement pour les nœuds LOD-développés) et évincées LRU hors viewport, comme des tuiles de carte.
+
+L'**aspect du monde** suit paresseusement l'aspect de la fenêtre : pendant un drag la caméra étire (déformation tolérée, bornée par hystérésis ~±20 %) ; au `viewDidEndLiveResize` ou au franchissement du seuil, **re-bake global animé** (morph, §3.4). Décision ⚖️ : c'est le seul événement autorisé à re-décider globalement — et il est **rare et animé**.
+
+### 3.2 La caméra : navigation carte continue
+`Camera` s'enrichit d'un état `(centre monde, échelle)` avec conversions vue↔monde exactes (inverse pour le hit-test). Gestes :
+
+- **Pan** : scroll deux doigts / drag (mode main). **Zoom** : pincement et molette, **vers le curseur** (le point sous la souris reste sous la souris — l'invariant Google Maps). **Double-clic** : zoom-to-fit animé du dossier (remplace le re-layout de `zoom(into:)` par un mouvement de caméra — l'animation actuelle devient *la* navigation). **⌘0 / breadcrumb / Home** : fit d'un ancêtre.
+- **Bornes** : zoom-min = monde entier (léger rubber-band), zoom-max = quand le plus petit fichier visible atteint ~40 px de côté.
+- **`zoomRoot` devient un dérivé de la caméra** : le dossier le plus profond dont le rect-monde contient ~le viewport. Breadcrumb, liste, résumé a11y s'y accrochent comme aujourd'hui — la sélection liste→carte fait un fit caméra, la navigation carte→liste suit le dérivé. L'état structurel disparaît ; l'URL mentale devient « où est la caméra ».
+
+### 3.3 LOD hiérarchique par taille projetée
+Le `maxDepth`/`minSide` statiques disparaissent au profit d'une règle par nœud, évaluée sur la **taille projetée à l'écran** (px = taille monde × échelle caméra) :
+
+- côté projeté < **T_collapse** (~8 px) → le dossier est rendu **agrégé** : une tuile de sa couleur `dominantExt` (le champ existe, [FSNode](../Sources/SpaceMatters/Model/FSNode.swift#L46)) ;
+- côté projeté > **T_expand** (~14 px) → ses enfants sont développés (hystérésis T_expand > T_collapse contre le *popping* au bord du seuil) ;
+- côté projeté > **T_files** (~400 px de côté) → ses **fichiers propres** apparaissent en tuiles individuelles — **généralisation de SPEC-05** : plus seulement le zoom root, tout dossier assez gros à l'écran. Layouts de fichiers calculés à la demande, cache LRU.
+
+La **subdivision est animée** : quand un dossier se développe, ses enfants naissent du rect parent et interpolent vers leurs rects (morph §3.4) — le « tile split » de Google Maps ; l'inverse au repli. Le set d'instances GPU est géré en **ranges contigus par sous-arbre développé**, reconstruits seulement quand le set LOD change ; une frame caméra-seule **ne réécrit aucun buffer** (nouveau chemin `render(cameraOnly:)` qui réutilise le dernier buffer — la copie actuelle par frame disparaît).
+
+### 3.4 Morph : tout re-bake est une transition
+Le vertex shader reçoit **deux buffers d'instances** (avant/après, appariés par nœud) + un uniforme `t` ; il interpole origine/taille (~200 ms, easing actuel). S'applique à : re-bake d'aspect (fin de drag), **ticks de scan et refreshes FSEvents** (coalescés à 10 Hz max — le monde « respire » au lieu de téléporter, le défaut des captures disparaît par construction), développement/repli LOD, futur passage 2D↔3D. Instances orphelines (nœud supprimé) fondent vers taille 0 ; nouvelles instances naissent du rect parent.
+
+### 3.5 Stabilité sous scan : invalidation locale (« local moves »)
+L'invalidation `version` cesse d'être globale : le scanner/FSEvents connaissent les **sous-arbres sales** — seules leurs entrées (rects relatifs, décisions) sont re-décidées ; les fratries dont les poids n'ont dérivé que sous un **ε** (~2 %) gardent leurs décisions (re-géométrie continue seule). C'est l'esprit « stable treemaps via local moves » (Sondag et al., TVCG 2018) appliqué à notre cache existant. Pendant le scan initial, le monde **se construit progressivement** : les entrées apparaissent au fil des données (streaming), le LOD borne ce qui est calculé — on ne layoute jamais 713 k dossiers d'un coup, seulement le visible + une marge.
+
+### 3.6 Présentation : pooling du drawable, overlay caméra-aware
+- **Drawable** : `drawableSize` arrondi au **palier de 256 px** supérieur, cadré via `contentsRect` → le pool d'IOSurfaces survit au drag (les allocations par frame mesurées au profil disparaissent). 🔬 à valider avec `presentsWithTransaction` ; repli = réallocation au seul `viewDidEndLiveResize`.
+- **Overlay** (spotlight sélection + hover) : ses 2-3 rects passent en **coordonnées monde**, transformés par la caméra à chaque present (coût trivial) → l'overlay **suit** pan/zoom/morph, le hover reste actif pendant les mouvements (l'inhibition actuelle saute). Le hit-test passe par l'inverse caméra (vue → monde → descente par containment dans les rects relatifs).
+
+## 4. Plan d'implémentation — jalons
+
+**M1 — Monde figé + caméra passive (~2-3 j)** : rects parent-relatifs dans `Cache.Entry` ; composition monde→instances ; resize = caméra seule + re-bake animé en fin de drag ; `render(cameraOnly:)` ; pooling drawable ; overlay/hit-test via inverse caméra ; hover actif pendant les mouvements. *Sortie : resize 120 Hz, part app ~0 dans le profil, plus aucun saut de blocs au resize.*
+
+**M2 — Navigation carte (~2-3 j)** : pan/zoom-au-curseur (scroll, pincement, molette), double-clic = fit animé, bornes + rubber-band, `zoomRoot` dérivé (breadcrumb/liste/a11y suivent), ⌘0/Home = fit racine. *Sortie : la feature « Google Maps ».*
+
+**M3 — LOD hiérarchique + fichiers (~4-5 j)** : seuils projetés + hystérésis, entrées lazy/LRU, ranges d'instances par sous-arbre, subdivision-morph, fichiers par dossier au-delà de T_files (généralise SPEC-05). *Sortie : zoomer révèle le détail, dézoomer agrège — à profondeur illimitée.*
+
+**M4 — Streaming & scan vivant (~3-4 j)** : invalidation par sous-arbre sale, ε-stabilité des décisions, morphs coalescés sur ticks/FSEvents, construction progressive pendant le scan. *Sortie : un scan en cours est un monde qui se remplit en douceur.*
+
+*(M5 = 3D : hors périmètre — voir §8.)*
+
+## 5. Vérification
+
+- **Stabilité (le bug des captures)** : script de référence — même scan, séquence resize → tick de version → resize ; les centroïdes des 20 plus gros blocs ne doivent pas bouger de > quelques % du monde (hors morphs explicites). Test unitaire pur sur les rects relatifs : re-layout à aspects différents ⇒ rects relatifs identiques.
+- **Perf** : re-profil Instruments du même scénario (protocole du 2026-07-12 : attach + warm-up ~10 s à absorber) — frame caméra < 1 ms CPU app ; zéro `CAIOSurfaceCreate` pendant un drag ; presents à la cadence vsync pendant pan/zoom.
+- **Précision** : zoom au max sur le plus petit fichier d'un scan 4 M — pas de jitter de géométrie (valide le re-basage caméra).
+- **LOD** : franchissements de seuils répétés (zoom oscillant) sans popping ni churn d'instances (hystérésis) ; budget mémoire entrées LRU borné et mesuré.
+- **Interaction** : hover/clic/menu/sélection pendant pan, zoom **et** morph ; breadcrumb cohérent avec le dérivé caméra ; a11y (résumé du dossier dominant) ; tests `TreemapLayout` existants verts (le squarify lui-même ne change pas).
+
+## 6. Risques & hypothèses (🔬)
+
+- 🔬 **Précision Float en zoom profond** — mitigée par parent-relatif + composition Double + re-basage caméra ; à prouver au jalon M1 (test du §5).
+- 🔬 **`contentsRect` × `presentsWithTransaction`** sur CAMetalLayer — à valider tôt ; repli documenté (§3.6).
+- 🔬 **Appariement avant/après du morph** sous scan agressif (nœuds qui naissent/meurent en rafale) — coalescence 10 Hz + naissance-du-parent doivent suffire ; sinon dégrader en cross-fade.
+- 🔬 **Modèle mental `zoomRoot` dérivé** : la liste et la carte peuvent diverger transitoirement pendant un pan — l'UX du breadcrumb « suit la caméra » est à éprouver (prototype M2 avant de figer).
+- ⚖️ **Molette = zoom** (convention carte) vs scroll = pan (convention document) : trancher au M2 (proposition : trackpad pan + pincement zoom, molette souris = zoom).
+- **Mémoire** : entrées complètes sur un arbre pathologique — bornée par LOD-lazy + LRU, à mesurer M3.
+- **Déformation pendant le drag** (aspect monde ≠ fenêtre dans la bande d'hystérésis) : assumée, bornée, corrigée par le re-bake animé de fin de drag.
+
+## 7. Effort & dépendances
+
+**~11-15 j** en 4 jalons livrables indépendamment (chacun laisse l'app meilleure qu'avant). Dépend de : PR #24 mergée (Metal-only). Aucune dépendance externe. Les 78 % de taxe AppKit/SwiftUI au resize de *fenêtre* ne sont **pas** dans ce périmètre (chantier chrome séparé) — mais pan/zoom, eux, ne touchent pas la fenêtre : la navigation carte tourne intégralement dans le budget GPU/caméra.
+
+## 8. Périmètre — ce que cette SPEC fait / ne fait PAS
+
+**Fait** : le paradigme monde (layout = données), caméra continue pan/zoom, LOD hiérarchique projeté (dossiers **et** fichiers), morphs sur tout changement, streaming sous scan, stabilité spatiale garantie et testée.
+**Ne fait PAS** : la 3D (hauteurs, perspective, orbite) — mais ce modèle en est le **prérequis propre** : SPEC-09 §9 s'active ensuite par caméra + hauteur sur un monde inchangé, le LOD et le morph s'appliquant tels quels aux boîtes. Pas de minimap (nice-to-have, à cadrer après M2). Pas de refonte du chrome SwiftUI (les 78 % du profil resize-fenêtre — chantier séparé). Le look des tuiles (palette, cushion, gouttières) ne change pas.


### PR DESCRIPTION
Implements [SPEC-10](https://github.com/Evariops/SpaceMatters/blob/feat/world-treemap/specs/SPEC-10-world-treemap.md), all four milestones, then hardens it through four rounds of live visual QA. Rebased on main (#24 merged). Net: +1617/−563.

## The paradigm inversion (`c23f433`)

- **`TreemapWorld`** (new): layout is a pure function of the tree. Each node stores its children's rects **parent-relative in the unit square**, decided once (squarify decisions frozen per node) and revalidated **ε-locally** on version bumps, so a scan tick or FSEvents refresh can no longer re-roll the whole tiling (pinned by test).
- **`WorldCamera`**: the viewport is a camera rect in world space. Window resize, pan and zoom are **matrix-only frames**, with no layout, no packing, no buffer writes (renderer split into `upload`/`draw`). Composition in Double, instances rebased on the built rect (floating origin) so Float precision holds at 10⁶× zoom.
- **Map navigation**: two-finger scroll pans, pinch and wheel zoom **toward the cursor**, double-click flies the camera into a folder. `zoomRoot` becomes a **derived value** (`cameraDidFocus`, debounced): breadcrumb and list follow the map, while explicit navigation (`zoom(into:)`, breadcrumb, ⌘↑) bumps `zoomRequestID` and answers with an animated camera fit.
- **LOD by projected size** with expand/collapse hysteresis (8/14 px) replaces the static depth/side caps. A folder whose file block projects over 400 px refines into individual file tiles (generalises SPEC-05 to any folder, LRU-cached).
- **Morphs**: structural transitions interpolate in the vertex shader (prev instance buffer plus t, 220 ms), and tile borders keep a constant *screen* width at any zoom (camera scale in the uniforms).

## Hardening from live QA (one commit per regression caught on a real 4 M-file scan)

- `bcfc1cd` **Resize black bands**: the SPEC-10 §3.6 pooled-drawable plus `contentsRect` crop produced giant black bands (the spec's 🔬 risk, confirmed) → reverted to exact per-frame drawableSize. **Wheel zoom**: precise-delta devices (tens per notch either way) made `pow(1.1, Δ)` teleport ×45 → normalised and clamped to ×1.15 per notch, matching pinch. **Black rectangles**: an expanded folder whose children all fall under the cull threshold punched a hole to the background → every expanded folder (and subdivided file block) now paints as an **underlay** beneath its children, and hover or click on gaps lands on the folder.
- `f73176f` **Zoom glitch (giant collapsing squares)**: newly expanded children started their morph on the parent's full rect, overlapping each other and their neighbours for 220 ms → LOD tiles now **appear in place** (Maps semantics), only tiles present in both builds slide, colours **cross-fade** (the per-rebuild brightness renormalisation fades instead of popping), and a rebuild landing mid-morph pairs from the **displayed** state (lerp at morphT), not the previous target.
- `695dd12` **Scattered tiles during scans**: 220 ms slides restarted by 10 Hz ticks never landed, so the map read as loose squares over the root underlay → a **live scan teleports** (every frame a coherent tiling, the pre-SPEC-10 behavior), while morphs remain for the calm post-scan life (FSEvents, deletions, metric flips, aspect re-bakes, LOD).
- `c3e88f4` **Sliver tiles (10:1)**: ε-drift was measured against the last revalidation with a moving baseline, so decisions frozen at scan-time weights survived unbounded cumulative drift → drift is now anchored to **decision-time shares**, the node's own **aspect drift** (±25 %) re-decides too (a parent re-place changes a child's aspect under its feet), and a **worst-tile-aspect guard (5:1)** re-decides locally whenever a kept decision stops reading as squarified. Self-healing regardless of cause.

## Deviations from the spec (all deliberate, spec to be amended on merge)

- Drawable pooling reverted (🔬 confirmed harmful). With camera-only resize the realloc is the only residual cost.
- Subdivision morph is **appear-in-place**, not grow-from-parent (geometric growth overlaps siblings, visually wrong).
- Live scans **teleport**, morphs are a post-scan behavior.
- Vanished tiles drop instead of melting to zero.

## Verification

- **57 tests green**, 9 new: world purity (the camera cannot move the world), ε-stability under small drift, **bounded worst-aspect under 40 ticks of cumulative drift**, LOD hysteresis, file-LOD refinement plus pending listings, focus derivation, camera invariants (anchor-fixed zoom, roundtrip), deep-zoom Double precision, renderer/shader init.
- Four rounds of live visual QA on a real scan of 4 M files / 714 k folders: fit render, resize, pinch and wheel zoom, double-click flights, live-scan rendering. The regressions caught are fixed above.
- Baseline for perf comparison: the 2026-07-12 Instruments profile (resize: 80 % main thread, ~16 ms CPU/frame, IOSurface churn). The camera-only path eliminates the app-side share by construction, and a re-profile is planned post-merge.
