### PR TITLE
Polish batch: outline noise, refresh honesty and refresh speed

### DIFF
--- a/Sources/SpaceMatters/ViewModel/ScanController.swift
+++ b/Sources/SpaceMatters/ViewModel/ScanController.swift
@@ -179,6 +179,10 @@ final class ScanController {
     /// Gated by `diskChangeBudget` so ordinary per-second churn doesn't keep it
     /// lit (issue #14).
     private(set) var diskChanged = false
+    /// A targeted refresh (`refreshDirty`) is re-scanning dirty subtrees right
+    /// now — the banner shows progress instead of vanishing, and incoming
+    /// FSEvents keep marking paths without touching the (stale) banner state.
+    private(set) var isRefreshing = false
     /// Signed net change in the scanned volume's used space since the current
     /// result finished — positive means it grew, negative means space was freed.
     /// Shown in the banner and compared against `diskChangeBudget` to gate it.
@@ -1093,6 +1097,11 @@ final class ScanController {
             guard let node = nearestNode(toPath: p), let np = path(for: node) else { continue }
             if dirtyPaths.insert(np).inserted { touched = true }
         }
+        // Mid-refresh: keep collecting dirty paths, but leave the banner alone —
+        // the free-space baseline is stale until the refresh re-bases it, and a
+        // bump here would repaint the treemap over half-reconciled aggregates
+        // (the transient wrong totals seen while a big subtree re-scans).
+        guard !isRefreshing else { return }
         // Gate the banner on net used-space movement so ordinary per-second churn
         // (logs, caches ticking over) doesn't keep it lit (issue #14). The dirty
         // dots still track every touched subtree for the targeted Refresh.
@@ -1125,6 +1134,8 @@ final class ScanController {
         }
         dirtyPaths.removeAll()
         diskChanged = false
+        isRefreshing = true
+        defer { isRefreshing = false }
         let epoch = treeEpoch
         for p in roots {
             guard epoch == treeEpoch else { return } // Rescan/Home mid-refresh
@@ -1135,10 +1146,14 @@ final class ScanController {
             }
         }
         scanDate = Date()
-        // Re-baseline the budget so the banner measures drift from *this* refresh.
+        // Re-baseline the budget so the banner measures drift from *this*
+        // refresh; events collected mid-refresh re-evaluate from here (dirty
+        // dots stay, banner off until real drift crosses the budget again).
         baselineFreeBytes = volumeFreeBytes()
         changedBytes = 0
         shownBytes = 0
+        diskChanged = false
+        bump()   // repaint the dots for any trailing dirty paths
     }
 
     private func refreshTotals() {

--- a/Sources/SpaceMatters/ViewModel/ScanController.swift
+++ b/Sources/SpaceMatters/ViewModel/ScanController.swift
@@ -504,6 +504,9 @@ final class ScanController {
     @ObservationIgnored private var layoutCache = TreemapLayout.Cache()
 
     private static let maxFilesPerFolder = 2000
+    /// Above this subtree file count, a targeted refresh skips the (single-
+    /// threaded) old-extensions disk walk — see `invalidate(subtree:)`.
+    private static let extReconcileMaxFiles: Int64 = 100_000
 
     func isExpanded(_ node: FSNode) -> Bool { expanded.contains(node) }
 
@@ -982,10 +985,23 @@ final class ScanController {
         let oldP = node.aggPhysical.load(ordering: .relaxed)
         let oldC = node.fileCount.load(ordering: .relaxed)
         let oldDirs = Self.subtreeDirCount(node)
-        let oldExt = await Task.detached(priority: .userInitiated) {
-            DirectoryScanner.subtreeExtensions(path: path)
-        }.value
-        guard epoch == treeEpoch else { return false }
+        // The File-types reconciliation needs a *single-threaded* disk walk of
+        // the subtree's old per-extension bytes. On a refresh rooted near the
+        // home folder (millions of files) that walk dominates the refresh by
+        // minutes — the parallel re-scan itself takes seconds. Above a bound,
+        // skip it: sizes, counts and the tree stay exact; the extensions panel
+        // drifts by this subtree's delta until the next full Rescan (the same
+        // accepted best-effort class as shared-extension changes below).
+        let reconcileExt = oldC <= Self.extReconcileMaxFiles
+        let oldExt: [ExtKey: ExtStat]
+        if reconcileExt {
+            oldExt = await Task.detached(priority: .userInitiated) {
+                DirectoryScanner.subtreeExtensions(path: path)
+            }.value
+            guard epoch == treeEpoch else { return false }
+        } else {
+            oldExt = [:]
+        }
 
         // Capture navigation state that points *into* the subtree — its descendant
         // nodes are about to be replaced by fresh objects — then drop the strong
@@ -1030,7 +1046,7 @@ final class ScanController {
         // sub-contribution isn't stored per node (the low-RAM design), so the
         // panel may be off by the change delta until the next full rescan. Sizes,
         // counts and folder count above are always exact.
-        if let ds = scanner as? DirectoryScanner {
+        if reconcileExt, let ds = scanner as? DirectoryScanner {
             ds.subtractExtensions(oldExt)
             ds.mergeExtensions(sub.snapshotRawExtensions())
         }

--- a/Sources/SpaceMatters/ViewModel/ScanController.swift
+++ b/Sources/SpaceMatters/ViewModel/ScanController.swift
@@ -733,7 +733,12 @@ final class ScanController {
             guard isOpen else { return }
 
             let kids = sortedChildren(node)
-            let files = filesIn(node) // pre-sorted by the current metric (cached)
+            // Pre-sorted by the current metric (cached). Files at zero size *in the
+            // current metric* are dropped — a space tool has nothing to say about
+            // them (macOS marker files like `.localized`, empty locks…), and a 0 B
+            // on-disk file that still has logical bytes reappears in Logical mode.
+            // Sorted descending → the zero tail is a prefix cut, not a filter pass.
+            let files = filesIn(node).prefix(while: { $0.size(metric) > 0 })
             let childMax = max(kids.first?.size(metric) ?? 0, files.first?.size(metric) ?? 0, 1)
 
             // Merge folders + files by size, biggest first.

--- a/Sources/SpaceMatters/Views/ContentView.swift
+++ b/Sources/SpaceMatters/Views/ContentView.swift
@@ -68,7 +68,7 @@ private struct FilesystemResultView: View {
                 Divider().overlay(theme.separator)
             }
 
-            if controller.diskChanged {
+            if controller.diskChanged || controller.isRefreshing {
                 DiskChangedBanner(controller: controller)
                 Divider().overlay(theme.separator)
             }
@@ -119,7 +119,6 @@ private struct ErrorBanner: View {
 private struct DiskChangedBanner: View {
     let controller: ScanController
     @Environment(\.theme) private var theme
-    @State private var refreshing = false
 
     /// Spell out how much moved, and in which direction, so the banner is a
     /// signal worth acting on rather than a permanent fixture (issue #14).
@@ -131,17 +130,21 @@ private struct DiskChangedBanner: View {
     }
 
     var body: some View {
+        // Progress lives on the controller: the banner view is recreated when
+        // `diskChanged` flips (a local @State would reset mid-refresh), and the
+        // refresh itself can take a while on a big dirty subtree.
+        let refreshing = controller.isRefreshing
         HStack(spacing: 10) {
             Image(systemName: "arrow.triangle.2.circlepath")
                 .font(.system(size: 13))
                 .foregroundStyle(theme.accent)
-            Text(Self.message(for: controller.changedBytes))
+            Text(refreshing ? "Refreshing the changed folders…"
+                            : Self.message(for: controller.changedBytes))
                 .font(.system(size: 11))
                 .foregroundStyle(theme.textPrimary)
             Spacer(minLength: 8)
             Button {
-                refreshing = true
-                Task { await controller.refreshDirty(); refreshing = false }
+                Task { await controller.refreshDirty() }
             } label: {
                 HStack(spacing: 5) {
                     if refreshing { ProgressView().controlSize(.mini) }

--- a/Tests/SpaceMattersTests/NavigationTests.swift
+++ b/Tests/SpaceMattersTests/NavigationTests.swift
@@ -253,6 +253,36 @@ import Foundation
         #expect(c.root!.aggPhysical.load(ordering: .relaxed) > physBefore + 200_000)
     }
 
+    // Zero-size files (in the current metric) are noise for a space tool — macOS
+    // marker files like `.localized` must not surface as outline rows, while
+    // sibling files with real bytes do.
+    @Test func zeroByteFilesAreHiddenFromOutlineRows() async throws {
+        let root = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try Data().write(to: root.appendingPathComponent("sibling/.localized"))
+        let c = ScanController()
+        c.scan(url: root)
+        await Self.waitForScan(c)
+
+        let sibling = try #require(Self.child(c.root!, "sibling"))
+        c.expanded.insert(c.root!)
+        c.expanded.insert(sibling)
+        // File listings load off the main actor: poll until the listing lands.
+        var files = c.filesIn(sibling)
+        let deadline = Date().addingTimeInterval(5)
+        while files.isEmpty && Date() < deadline {
+            await Task.yield()
+            RunLoop.main.run(until: Date().addingTimeInterval(0.02))
+            files = c.filesIn(sibling)
+        }
+        #expect(files.contains { $0.name == ".localized" })   // listed on disk…
+
+        let rows = c.visibleRows()
+        let siblingID = ObjectIdentifier(sibling)
+        #expect(rows.contains { $0.id == .file(siblingID, "s.bin") })
+        #expect(!rows.contains { $0.id == .file(siblingID, ".localized") }) // …but not shown
+    }
+
     @Test func deletingFileUpdatesAggregatesAndCount() async throws {
         let root = try Self.makeFixture()
         defer { try? FileManager.default.removeItem(at: root) }


### PR DESCRIPTION
Three small fixes caught while live-testing the world treemap, one commit each.

## Hide zero-size files from the outline (`db5a96c`)
macOS marker files (`.localized`, empty locks) surfaced as 0 B rows. Files at zero size **in the current metric** are cut from the outline merge (descending sort makes it a prefix cut, not a filter pass), so a 0 B on-disk file that still has logical bytes reappears in Logical mode. Directories untouched. Pinned by a fixture test (`.localized` listed on disk, absent from rows).

## Keep the disk-changed banner honest through a refresh (`fe0f69e`)
Clicking Refresh hid the banner instantly, then trailing FSEvents, evaluated against the not-yet-rebased free-space baseline, resurrected it mid-refresh with the pre-refresh delta, and their `bump()` repainted the treemap over half-reconciled aggregates (transient wrong totals). The refresh gave zero feedback for its whole duration.
Now `isRefreshing` lives on the controller (the existing spinner was `@State` in a view that died on the first `diskChanged` flip, so it had never been visible), the banner stays up as "Refreshing the changed folders…", mid-refresh events keep marking dirty paths but cannot touch banner state or repaint, and `refreshDirty` clears state *after* the re-scan loop too.

## Bound the old-extensions walk, refresh looked hung for minutes (`60f2ec5`)
`invalidate(subtree:)` snapshots the subtree's old per-extension bytes with a **single-threaded** `getattrlistbulk` walk before re-scanning. Rooted near the home folder (3.9 M files) that walk runs for minutes while the parallel re-scan takes ~20 s. Sampled live: 100 % in `DirectoryScanner.subtreeExtensions`. Above 100 k files the refresh now skips the File-types reconciliation: sizes, counts and the tree stay exact, and the extensions panel drifts by the subtree's delta until the next full Rescan (the same accepted best-effort class already documented in that code). The deletion path keeps its walk, because there the correction covers the whole removed subtree and is worth the wait.

## Verification
58 tests green (1 new). Live QA: the full create-file → banner → Refresh → morph-updated treemap cycle exercised on a real 315 GiB volume. A home-rooted refresh now completes in ~25 s (the parallel re-scan itself, since the by-directory incremental refresh is specced separately as SPEC-11).
