### PR TITLE
Low-Hanging Fruits hardening: native cleaners, active-tool warnings, lifecycle and honesty fixes (4 major, 9 minor)

### DIFF
--- a/Sources/SpaceMatters/Scanner/CleanupEngine.swift
+++ b/Sources/SpaceMatters/Scanner/CleanupEngine.swift
@@ -127,6 +127,7 @@ enum CleanupEngine {
     static func size(of item: Cleanable) -> Measure {
         var total: Int64 = 0
         var openedAny = false
+        var deniedRoot = false
         let buffer = UnsafeMutableRawPointer.allocate(byteCount: bufferSize, alignment: 16)
         defer { buffer.deallocate() }
 
@@ -137,7 +138,14 @@ enum CleanupEngine {
                 // target (detect refuses it; clean would too), and a directory
                 // swapped for a link between enumeration and open is not chased.
                 let fd = open(dir, O_RDONLY | O_DIRECTORY | O_NOFOLLOW)
-                guard fd >= 0 else { continue }
+                guard fd >= 0 else {
+                    // ENOENT and EACCES are different stories: a root that no
+                    // longer exists is *empty* (native cleaners like dotnet
+                    // remove their directories outright), only a root we're not
+                    // allowed to open reads as "needs access".
+                    if dir == root && (errno == EACCES || errno == EPERM) { deniedRoot = true }
+                    continue
+                }
                 if dir == root { openedAny = true }
                 let prefix = dir + "/"
                 _ = enumerateDirectory(fd: fd, buffer: buffer, bufferSize: bufferSize) { entry in
@@ -155,7 +163,8 @@ enum CleanupEngine {
                 close(fd)
             }
         }
-        return openedAny ? .sized(total) : .denied
+        if openedAny { return .sized(total) }
+        return deniedRoot ? .denied : .sized(0)
     }
 
     // MARK: Cleaning
@@ -184,13 +193,18 @@ enum CleanupEngine {
         let fm = FileManager.default
 
         for root in item.paths {
+            var rootStat = stat()
+            if lstat(root, &rootStat) != 0 {
+                // A vanished root is nothing to clean, not a fence violation —
+                // a native cleaner may have removed the directory outright.
+                if errno != ENOENT { result.failed += 1 }
+                continue
+            }
             guard passesFence(root, allowedRoot: allowedRoot) else {
                 result.refused += 1
                 continue
             }
-            var rootStat = stat()
-            guard lstat(root, &rootStat) == 0,
-                  let children = try? fm.contentsOfDirectory(atPath: root) else {
+            guard let children = try? fm.contentsOfDirectory(atPath: root) else {
                 result.failed += 1
                 continue
             }

--- a/Sources/SpaceMatters/Scanner/CleanupEngine.swift
+++ b/Sources/SpaceMatters/Scanner/CleanupEngine.swift
@@ -98,10 +98,14 @@ enum CleanupEngine {
         ]
     }
 
-    /// The catalog restricted to entries with at least one existing path.
-    static func detect(_ catalog: [Cleanable]) -> [Cleanable] {
+    /// The catalog restricted to entries with at least one path that passes the
+    /// same fence as `clean` (existing real directory, no symlinked root, still
+    /// inside `allowedRoot` once resolved). Deciding at detection time keeps the
+    /// UI honest: a relocated cache is never shown, sized through its link, and
+    /// then refused at cleaning time with gigabytes left on screen.
+    static func detect(_ catalog: [Cleanable], allowedRoot: String = NSHomeDirectory()) -> [Cleanable] {
         catalog.compactMap { item in
-            let existing = item.paths.filter { FileManager.default.fileExists(atPath: $0) }
+            let existing = item.paths.filter { passesFence($0, allowedRoot: allowedRoot) }
             guard !existing.isEmpty else { return nil }
             return Cleanable(id: item.id, name: item.name, category: item.category,
                              icon: item.icon, note: item.note, paths: existing)
@@ -129,7 +133,10 @@ enum CleanupEngine {
         for root in item.paths {
             var stack = [root]
             while let dir = stack.popLast() {
-                let fd = open(dir, O_RDONLY | O_DIRECTORY)
+                // O_NOFOLLOW: a symlinked root must not be measured through its
+                // target (detect refuses it; clean would too), and a directory
+                // swapped for a link between enumeration and open is not chased.
+                let fd = open(dir, O_RDONLY | O_DIRECTORY | O_NOFOLLOW)
                 guard fd >= 0 else { continue }
                 if dir == root { openedAny = true }
                 let prefix = dir + "/"
@@ -175,22 +182,31 @@ enum CleanupEngine {
     static func clean(_ item: Cleanable, allowedRoot: String = NSHomeDirectory()) -> CleanResult {
         var result = CleanResult()
         let fm = FileManager.default
-        let fence = allowedRoot.hasSuffix("/") ? allowedRoot : allowedRoot + "/"
 
         for root in item.paths {
-            guard root.hasPrefix(fence), root != fence, isRealDirectory(root),
-                  staysInsideFence(root, allowedRoot: allowedRoot) else {
+            guard passesFence(root, allowedRoot: allowedRoot) else {
                 result.refused += 1
                 continue
             }
-            guard let children = try? fm.contentsOfDirectory(atPath: root) else {
+            var rootStat = stat()
+            guard lstat(root, &rootStat) == 0,
+                  let children = try? fm.contentsOfDirectory(atPath: root) else {
                 result.failed += 1
                 continue
             }
             for child in children {
+                let childPath = root + "/" + child
+                // A volume mounted inside a cache is not the cache's data: skip
+                // it like the sizing walk does. Same family as fence refusals.
+                var st = stat()
+                if lstat(childPath, &st) == 0, (st.st_mode & S_IFMT) == S_IFDIR,
+                   st.st_dev != rootStat.st_dev {
+                    result.refused += 1
+                    continue
+                }
                 // removeItem on a symlink deletes the link, not its target.
                 do {
-                    try fm.removeItem(atPath: root + "/" + child)
+                    try fm.removeItem(atPath: childPath)
                     result.removed += 1
                 } catch {
                     result.failed += 1
@@ -198,6 +214,15 @@ enum CleanupEngine {
             }
         }
         return result
+    }
+
+    /// The full fence, shared by `detect` and `clean` so both always agree:
+    /// textual prefix (cheap, fail-closed), a real non-symlink directory, and a
+    /// fully-resolved form still strictly inside the resolved fence.
+    private static func passesFence(_ root: String, allowedRoot: String) -> Bool {
+        let fence = allowedRoot.hasSuffix("/") ? allowedRoot : allowedRoot + "/"
+        return root.hasPrefix(fence) && root != fence && isRealDirectory(root)
+            && staysInsideFence(root, allowedRoot: allowedRoot)
     }
 
     /// True only for a directory that is not itself a symlink (`lstat`, so the

--- a/Sources/SpaceMatters/Scanner/CleanupEngine.swift
+++ b/Sources/SpaceMatters/Scanner/CleanupEngine.swift
@@ -57,11 +57,11 @@ enum CleanupEngine {
                 paths: [home + "/Library/Caches/Yarn"]),
             Cleanable(
                 id: "pnpm", name: "pnpm store", category: "JavaScript", icon: "shippingbox",
-                note: "Content-addressable package store, re-downloaded on demand.",
+                note: "Package store — projects keep their files (hard links), re-downloaded on demand.",
                 paths: [home + "/Library/pnpm/store", home + "/.pnpm-store"]),
             Cleanable(
                 id: "nuget", name: "NuGet packages", category: ".NET", icon: "archivebox.fill",
-                note: "Global packages + HTTP cache, restored on next build.",
+                note: "Global packages + HTTP cache, restored on next build (needs feed access).",
                 paths: [
                     home + "/.nuget/packages",
                     home + "/.local/share/NuGet/http-cache",
@@ -81,7 +81,7 @@ enum CleanupEngine {
                 paths: [home + "/.gradle/caches"]),
             Cleanable(
                 id: "maven", name: "Maven repository", category: "JVM", icon: "gearshape.2",
-                note: "Local artifact repository, re-downloaded on next build.",
+                note: "Re-downloaded on next build — except JARs installed by hand (install:install-file).",
                 paths: [home + "/.m2/repository"]),
             Cleanable(
                 id: "cargo", name: "Cargo registry", category: "Rust & Go", icon: "wrench.and.screwdriver.fill",
@@ -93,7 +93,7 @@ enum CleanupEngine {
                 paths: [home + "/Library/Caches/go-build"]),
             Cleanable(
                 id: "homebrew", name: "Homebrew downloads", category: "Homebrew", icon: "mug.fill",
-                note: "Bottle and formula downloads (what `brew cleanup` removes).",
+                note: "Bottle, cask and API downloads, re-fetched on demand.",
                 paths: [home + "/Library/Caches/Homebrew"]),
         ]
     }
@@ -223,6 +223,26 @@ enum CleanupEngine {
         let fence = allowedRoot.hasSuffix("/") ? allowedRoot : allowedRoot + "/"
         return root.hasPrefix(fence) && root != fence && isRealDirectory(root)
             && staysInsideFence(root, allowedRoot: allowedRoot)
+    }
+
+    /// uv `link-mode = symlink` makes every virtualenv point INTO the cache:
+    /// cleaning it would break all installed packages — uv's own docs say the
+    /// same of `uv cache clean`. Checked from the environment and uv's
+    /// user-level config; when true, the uv target must not be offered.
+    static func uvSymlinkMode(home: String = NSHomeDirectory(),
+                              environment: [String: String] = ProcessInfo.processInfo.environment) -> Bool {
+        if environment["UV_LINK_MODE"] == "symlink" { return true }
+        let configDir = environment["XDG_CONFIG_HOME"] ?? (home + "/.config")
+        guard let text = try? String(contentsOfFile: configDir + "/uv/uv.toml", encoding: .utf8) else {
+            return false
+        }
+        for line in text.split(separator: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if !trimmed.hasPrefix("#"), trimmed.hasPrefix("link-mode"), trimmed.contains("symlink") {
+                return true
+            }
+        }
+        return false
     }
 
     /// True only for a directory that is not itself a symlink (`lstat`, so the

--- a/Sources/SpaceMatters/Scanner/NativeCleaner.swift
+++ b/Sources/SpaceMatters/Scanner/NativeCleaner.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// The vendor's own cleaner for a cleanup target, preferred over file removal
+/// when its binary is installed — the tool brings semantics a file walk cannot
+/// have. Homebrew coordinates through its own locks, so a concurrent `brew`
+/// fails cleanly instead of losing an app mid-`upgrade --cask`; `pnpm store
+/// prune` removes only packages no project references; `dotnet` and `go`
+/// resolve their own configured cache locations, env overrides included.
+///
+/// When a native run fails, nothing falls back to file removal in the same
+/// pass: the failure may be exactly the vendor's lock doing its job, and
+/// deleting the files underneath it would recreate the race the native path
+/// exists to close.
+struct NativeCleaner: Sendable, Equatable {
+    let binary: String
+    let arguments: [String]
+    let environment: [String: String]
+    let timeout: TimeInterval
+    /// Display name shown in the row and the journal ("brew cleanup").
+    let label: String
+
+    /// The native cleaner for a catalog target, when its binary exists.
+    /// Candidates are fixed absolute paths: a GUI app inherits no shell PATH,
+    /// and probing the known install prefixes beats guessing an environment.
+    /// Targets deliberately absent (npm, pip, yarn…) gain nothing from their
+    /// vendor command — their caches are designed for plain removal.
+    static func available(
+        for targetID: String, home: String = NSHomeDirectory(),
+        isExecutable: (String) -> Bool = { FileManager.default.isExecutableFile(atPath: $0) }
+    ) -> NativeCleaner? {
+        guard let spec = specs(home: home)[targetID],
+              let binary = spec.candidates.first(where: isExecutable) else { return nil }
+        return NativeCleaner(binary: binary, arguments: spec.arguments,
+                             environment: spec.environment, timeout: spec.timeout,
+                             label: spec.label)
+    }
+
+    private struct Spec {
+        let candidates: [String]
+        let arguments: [String]
+        let environment: [String: String]
+        let timeout: TimeInterval
+        let label: String
+    }
+
+    /// Cleaning tens of gigabytes can be legitimately slow — same 10 min
+    /// deadline as the container actions, watchdog-killed past that.
+    private static func specs(home: String) -> [String: Spec] {
+        [
+            "homebrew": Spec(
+                candidates: ["/opt/homebrew/bin/brew", "/usr/local/bin/brew"],
+                arguments: ["cleanup", "-s", "--prune=all"],
+                // Hygiene: a cleaner must not update taps or phone home.
+                environment: ["HOMEBREW_NO_AUTO_UPDATE": "1",
+                              "HOMEBREW_NO_ANALYTICS": "1",
+                              "HOMEBREW_NO_ENV_HINTS": "1"],
+                timeout: 600, label: "brew cleanup"),
+            "pnpm": Spec(
+                candidates: [home + "/Library/pnpm/pnpm",
+                             "/opt/homebrew/bin/pnpm", "/usr/local/bin/pnpm"],
+                arguments: ["store", "prune"],
+                environment: [:], timeout: 600, label: "pnpm store prune"),
+            "nuget": Spec(
+                candidates: ["/usr/local/share/dotnet/dotnet",
+                             "/opt/homebrew/bin/dotnet", "/usr/local/bin/dotnet"],
+                arguments: ["nuget", "locals", "all", "--clear"],
+                environment: [:], timeout: 600, label: "dotnet nuget locals --clear"),
+            "go-build": Spec(
+                candidates: ["/opt/homebrew/bin/go", "/usr/local/go/bin/go",
+                             "/usr/local/bin/go"],
+                arguments: ["clean", "-cache"],
+                environment: [:], timeout: 600, label: "go clean -cache"),
+        ]
+    }
+}

--- a/Sources/SpaceMatters/Util/CleanupJournal.swift
+++ b/Sources/SpaceMatters/Util/CleanupJournal.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// One JSON line per cleaned target, appended to
+/// `~/Library/Logs/SpaceMatters/cleanup.jsonl` — the forensic trail behind any
+/// field report: what did the app touch, when, with which engine, what was
+/// running at the time, and how did it end. Best-effort by design: journaling
+/// must never fail or slow a clean.
+enum CleanupJournal {
+    struct Entry: Codable, Equatable {
+        var timestamp: Date = .init()
+        let targetID: String
+        /// "file" for the built-in engine, the native label otherwise.
+        var engine: String
+        let paths: [String]
+        let bytesBefore: Int64
+        var bytesAfter: Int64 = 0
+        var removed = 0
+        var failed = 0
+        var refused = 0
+        /// Native cleaner failure, when one happened.
+        var diagnostic: String?
+        /// Tools detected running for this target when the clean started.
+        var activeTools: [String] = []
+    }
+
+    static func append(_ entry: Entry, directory: URL = defaultDirectory) {
+        let fm = FileManager.default
+        try? fm.createDirectory(at: directory, withIntermediateDirectories: true)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        guard var line = try? encoder.encode(entry) else { return }
+        line.append(0x0A)
+        let file = directory.appendingPathComponent("cleanup.jsonl")
+        if let handle = try? FileHandle(forWritingTo: file) {
+            defer { try? handle.close() }
+            _ = try? handle.seekToEnd()
+            try? handle.write(contentsOf: line)
+        } else {
+            try? line.write(to: file)
+        }
+    }
+
+    static var defaultDirectory: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Logs/SpaceMatters")
+    }
+}

--- a/Sources/SpaceMatters/Util/ProcessRunner.swift
+++ b/Sources/SpaceMatters/Util/ProcessRunner.swift
@@ -66,10 +66,16 @@ enum ProcessTree {
 /// deadlock (a chatty child that fills the pipe while we wait on exit).
 enum ProcessRunner {
     /// Synchronous run with a deadline. Safe to call from a detached task.
-    static func runSync(_ executable: String, _ args: [String], timeout: TimeInterval = 20) -> ProcessResult {
+    /// `environment` entries are merged over the inherited environment.
+    static func runSync(_ executable: String, _ args: [String], timeout: TimeInterval = 20,
+                        environment: [String: String]? = nil) -> ProcessResult {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: executable)
         process.arguments = args
+        if let environment {
+            process.environment = ProcessInfo.processInfo.environment
+                .merging(environment) { _, override in override }
+        }
         let outPipe = Pipe(), errPipe = Pipe()
         process.standardOutput = outPipe
         process.standardError = errPipe
@@ -78,10 +84,15 @@ enum ProcessRunner {
 
     /// Async run with the same deadline, plus cooperative cancellation: cancelling
     /// the surrounding `Task` terminates the process instead of waiting it out.
-    static func run(_ executable: String, _ args: [String], timeout: TimeInterval = 20) async -> ProcessResult {
+    static func run(_ executable: String, _ args: [String], timeout: TimeInterval = 20,
+                    environment: [String: String]? = nil) async -> ProcessResult {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: executable)
         process.arguments = args
+        if let environment {
+            process.environment = ProcessInfo.processInfo.environment
+                .merging(environment) { _, override in override }
+        }
         let outPipe = Pipe(), errPipe = Pipe()
         process.standardOutput = outPipe
         process.standardError = errPipe

--- a/Sources/SpaceMatters/Util/ToolActivity.swift
+++ b/Sources/SpaceMatters/Util/ToolActivity.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+/// Which running developer tools make cleaning a given target risky right now.
+///
+/// Cleaning a cache under a tool that is using it makes the tool's in-flight
+/// operation fail (a build, an install, an upgrade). The dangerous case —
+/// Homebrew mid-`upgrade --cask`, whose uninstall→reinstall window sources
+/// from the cache — is closed structurally by running `brew cleanup` instead
+/// of deleting files (NativeCleaner). Everything else gets a *named* warning
+/// in the confirmation dialog, not a lock: best-effort, same-user processes
+/// only, matched on the kernel's `p_comm` (argv is read only to tell a Gradle
+/// daemon or Maven apart from any other JVM).
+enum ToolActivity {
+
+    /// target id → display names of the tools found running.
+    static func activeTools(for targetIDs: Set<String>) -> [String: Set<String>] {
+        var found: [String: Set<String>] = [:]
+        for proc in processList() {
+            for hit in classify(comm: proc.comm, argv: arguments(of: proc.pid))
+            where targetIDs.contains(hit.target) {
+                found[hit.target, default: []].insert(hit.tool)
+            }
+        }
+        return found
+    }
+
+    /// Pure classification, injectable in tests: one process (its `p_comm`,
+    /// argv fetched lazily — only JVMs need it) → the targets it puts at risk.
+    static func classify(comm: String, argv: @autoclosure () -> [String])
+        -> [(target: String, tool: String)] {
+        if let targets = commTargets[comm] {
+            return targets.map { ($0, comm) }
+        }
+        guard comm == "java" else { return [] }
+        let joined = argv().joined(separator: " ")
+        if joined.contains("org.gradle.launcher.daemon") { return [("gradle", "a Gradle daemon")] }
+        if joined.contains("org.codehaus.plexus.classworlds") { return [("maven", "Maven")] }
+        return []
+    }
+
+    /// `p_comm` (16 chars, enough for every name here) → catalog target ids.
+    /// `brew` is the bash wrapper script, alive for the whole run — the ruby
+    /// child doesn't need matching. Xcode builds also touch the SwiftPM cache
+    /// (package resolution), hence the double mapping.
+    private static let commTargets: [String: [String]] = [
+        "Xcode": ["derived-data", "swiftpm"],
+        "xcodebuild": ["derived-data", "swiftpm"],
+        "swift-build": ["swiftpm"],
+        "swift-package": ["swiftpm"],
+        "pod": ["cocoapods"],
+        "npm": ["npm"],
+        "npx": ["npm"],
+        "yarn": ["yarn"],
+        "pnpm": ["pnpm"],
+        "dotnet": ["nuget"],
+        "msbuild": ["nuget"],
+        "pip": ["pip"],
+        "pip3": ["pip"],
+        "uv": ["uv"],
+        "gradle": ["gradle"],
+        "mvn": ["maven"],
+        "mvnd": ["maven"],
+        "cargo": ["cargo"],
+        "go": ["go-build"],
+        "brew": ["homebrew"],
+    ]
+
+    // MARK: Process plumbing
+
+    /// Same-uid processes with their kernel short name. One sysctl, no
+    /// privileges needed; failures degrade to "no warning", never to a block.
+    private static func processList() -> [(pid: pid_t, comm: String)] {
+        var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_UID, Int32(getuid())]
+        var size = 0
+        guard sysctl(&mib, 4, nil, &size, nil, 0) == 0, size > 0 else { return [] }
+        size += MemoryLayout<kinfo_proc>.stride * 16 // headroom: procs spawn between the two calls
+        let buffer = UnsafeMutableRawPointer.allocate(
+            byteCount: size, alignment: MemoryLayout<kinfo_proc>.alignment)
+        defer { buffer.deallocate() }
+        guard sysctl(&mib, 4, buffer, &size, nil, 0) == 0 else { return [] }
+
+        let count = size / MemoryLayout<kinfo_proc>.stride
+        let procs = buffer.bindMemory(to: kinfo_proc.self, capacity: count)
+        return (0..<count).compactMap { i in
+            let pid = procs[i].kp_proc.p_pid
+            guard pid > 0 else { return nil }
+            let comm = withUnsafeBytes(of: procs[i].kp_proc.p_comm) { raw in
+                String(decoding: raw.prefix(while: { $0 != 0 }), as: UTF8.self)
+            }
+            return (pid, comm)
+        }
+    }
+
+    /// argv of a same-uid process via `KERN_PROCARGS2`. Layout: argc (Int32),
+    /// exec_path NUL-terminated, NUL padding, then argc NUL-terminated args
+    /// (environment follows — never read). Any failure returns [].
+    private static func arguments(of pid: pid_t) -> [String] {
+        var mib: [Int32] = [CTL_KERN, KERN_PROCARGS2, pid]
+        var size = 0
+        guard sysctl(&mib, 3, nil, &size, nil, 0) == 0,
+              size > MemoryLayout<Int32>.size else { return [] }
+        var buf = [UInt8](repeating: 0, count: size)
+        guard sysctl(&mib, 3, &buf, &size, nil, 0) == 0,
+              size > MemoryLayout<Int32>.size else { return [] }
+
+        let argc = Int(buf.withUnsafeBytes { $0.load(as: Int32.self) })
+        var idx = MemoryLayout<Int32>.size
+        while idx < size && buf[idx] != 0 { idx += 1 } // skip exec_path
+        while idx < size && buf[idx] == 0 { idx += 1 } // skip padding
+
+        var args: [String] = []
+        var start = idx
+        while idx < size && args.count < argc {
+            if buf[idx] == 0 {
+                args.append(String(decoding: buf[start..<idx], as: UTF8.self))
+                start = idx + 1
+            }
+            idx += 1
+        }
+        return args
+    }
+}

--- a/Sources/SpaceMatters/ViewModel/CleanupController.swift
+++ b/Sources/SpaceMatters/ViewModel/CleanupController.swift
@@ -259,7 +259,17 @@ final class CleanupController {
     private func apply(_ measure: CleanupEngine.Measure, to id: String) {
         guard let idx = rows.firstIndex(where: { $0.id == id }) else { return }
         switch measure {
-        case .sized(let bytes): rows[idx].size = .sized(bytes)
+        case .sized(let bytes):
+            // An empty target on the initial sizing pass is noise — nothing to
+            // reclaim, the row doesn't earn its place (the file engine keeps
+            // cache roots alive by design, so empties are common after a past
+            // clean). The same 0 B arriving during `.cleaning` is the *result*
+            // of this clean: the row stays as feedback until the next reload.
+            if bytes == 0, state == .sizing {
+                rows.remove(at: idx)
+            } else {
+                rows[idx].size = .sized(bytes)
+            }
         case .denied: rows[idx].size = .denied
         }
         if state == .sizing, !rows.contains(where: { $0.size == .pending }) {

--- a/Sources/SpaceMatters/ViewModel/CleanupController.swift
+++ b/Sources/SpaceMatters/ViewModel/CleanupController.swift
@@ -15,6 +15,9 @@ final class CleanupController {
         case sized(Int64)
         /// Exists but unreadable — typically the Trash without Full Disk Access.
         case denied
+        /// Cleaning this target on this machine would break things (uv in
+        /// `link-mode=symlink`) — never sized, never selectable, reason shown.
+        case blocked(String)
     }
 
     struct Row: Identifiable {
@@ -47,11 +50,13 @@ final class CleanupController {
     /// lands, instead of being dropped (or worse, resetting rows under it).
     private var pendingReload = false
 
-    /// Which native cleaner (if any) handles a target, and how one is executed.
-    /// Both are injectable: cleaning is destructive, tests must be able to
-    /// observe it without ever spawning a real tool.
+    /// Which native cleaner (if any) handles a target, how one is executed, and
+    /// which targets are blocked outright on this machine. All injectable:
+    /// cleaning is destructive, tests must be able to observe every path
+    /// without spawning a real tool or depending on this machine's config.
     private let nativeLookup: @Sendable (String, String) -> NativeCleaner?
     private let nativeRunner: @Sendable (NativeCleaner) async -> ProcessResult
+    private let blockedReason: @Sendable (String, String) -> String?
 
     /// `catalog`/`allowedRoot` are injectable so tests can run against fixtures;
     /// the app uses the built-in catalog fenced to the user's home.
@@ -62,11 +67,17 @@ final class CleanupController {
          nativeRunner: @escaping @Sendable (NativeCleaner) async -> ProcessResult = { native in
             await ProcessRunner.run(native.binary, native.arguments,
                                     timeout: native.timeout, environment: native.environment)
+         },
+         blockedReason: @escaping @Sendable (String, String) -> String? = { id, home in
+            id == "uv" && CleanupEngine.uvSymlinkMode(home: home)
+                ? "uv link-mode is \"symlink\" — cleaning would break your virtualenvs"
+                : nil
          }) {
         self.catalog = catalog
         self.allowedRoot = allowedRoot
         self.nativeLookup = nativeLookup
         self.nativeRunner = nativeRunner
+        self.blockedReason = blockedReason
     }
 
     func load() {
@@ -84,15 +95,20 @@ final class CleanupController {
         lastRefused = 0
         lastNativeIssues = []
         let detected = CleanupEngine.detect(catalog, allowedRoot: allowedRoot)
-        // Keep existing selections across a refresh; drop ones that vanished.
+        let blocked = Dictionary(uniqueKeysWithValues: detected.compactMap { item in
+            blockedReason(item.id, allowedRoot).map { (item.id, $0) }
+        })
+        // Keep existing selections across a refresh; drop ones that vanished
+        // (or got blocked meanwhile).
         let previouslySelected = Set(rows.filter(\.selected).map(\.id))
         rows = detected.map {
             Row(item: $0,
                 nativeLabel: nativeLookup($0.id, allowedRoot)?.label,
-                selected: previouslySelected.contains($0.id))
+                size: blocked[$0.id].map(SizeState.blocked) ?? .pending,
+                selected: previouslySelected.contains($0.id) && blocked[$0.id] == nil)
         }
-        state = rows.isEmpty ? .ready : .sizing
-        for item in detected {
+        state = rows.contains { $0.size == .pending } ? .sizing : .ready
+        for item in detected where blocked[item.id] == nil {
             Task {
                 let measure = await Task.detached(priority: .userInitiated) {
                     CleanupEngine.size(of: item)
@@ -112,8 +128,11 @@ final class CleanupController {
         pendingReload = false
     }
 
+    /// The model guards itself: a pending/denied/blocked row cannot be selected
+    /// however the call arrives, not just because the checkbox is disabled.
     func toggle(_ id: String) {
-        guard let idx = rows.firstIndex(where: { $0.id == id }) else { return }
+        guard let idx = rows.firstIndex(where: { $0.id == id }),
+              rows[idx].size.isSelectable else { return }
         rows[idx].selected.toggle()
     }
 
@@ -121,10 +140,17 @@ final class CleanupController {
 
     enum SelectAllState { case none, some, all }
 
-    /// Select-all checkbox state over the *selectable* rows (denied/pending
-    /// rows have no trustworthy size and never count).
+    /// Select-all drives the *cache* rows only. The Trash is the one target
+    /// that is user data, not a regenerable cache — it is selected row by row,
+    /// never swept up in momentum, and the header checkbox ignores it both ways.
+    private func isBulkSelectable(_ row: Row) -> Bool {
+        row.size.isSelectable && row.item.id != "trash"
+    }
+
+    /// Select-all checkbox state over the bulk-selectable rows (denied/pending/
+    /// blocked rows have no trustworthy size and never count; nor does Trash).
     var selectAllState: SelectAllState {
-        let selectable = rows.filter(\.size.isSelectable)
+        let selectable = rows.filter(isBulkSelectable)
         let selected = selectable.filter(\.selected).count
         if selected == 0 { return .none }
         return selected == selectable.count ? .all : .some
@@ -133,8 +159,8 @@ final class CleanupController {
     /// Standard macOS cycle: all → none; none or mixed → all.
     func toggleAll() {
         let target = selectAllState != .all
-        for idx in rows.indices {
-            rows[idx].selected = target && rows[idx].size.isSelectable
+        for idx in rows.indices where isBulkSelectable(rows[idx]) {
+            rows[idx].selected = target
         }
     }
 

--- a/Sources/SpaceMatters/ViewModel/CleanupController.swift
+++ b/Sources/SpaceMatters/ViewModel/CleanupController.swift
@@ -19,6 +19,8 @@ final class CleanupController {
 
     struct Row: Identifiable {
         let item: Cleanable
+        /// Set when the vendor's own cleaner will run instead of file removal.
+        var nativeLabel: String?
         var size: SizeState = .pending
         var selected = false
         var id: String { item.id }
@@ -33,6 +35,10 @@ final class CleanupController {
     /// Paths the safety fence refused during the last clean — a bug indicator
     /// (detect and clean disagreeing), surfaced distinctly from plain failures.
     private(set) var lastRefused = 0
+    /// Native cleaners that exited non-zero during the last clean ("Homebrew —
+    /// brew cleanup: …"). Surfaced as an alert; never retried as file removal —
+    /// the failure may be the vendor's lock doing its job.
+    private(set) var lastNativeIssues: [String] = []
 
     private let catalog: [Cleanable]
     private let allowedRoot: String
@@ -41,12 +47,26 @@ final class CleanupController {
     /// lands, instead of being dropped (or worse, resetting rows under it).
     private var pendingReload = false
 
+    /// Which native cleaner (if any) handles a target, and how one is executed.
+    /// Both are injectable: cleaning is destructive, tests must be able to
+    /// observe it without ever spawning a real tool.
+    private let nativeLookup: @Sendable (String, String) -> NativeCleaner?
+    private let nativeRunner: @Sendable (NativeCleaner) async -> ProcessResult
+
     /// `catalog`/`allowedRoot` are injectable so tests can run against fixtures;
     /// the app uses the built-in catalog fenced to the user's home.
     init(catalog: [Cleanable] = CleanupEngine.catalog(),
-         allowedRoot: String = NSHomeDirectory()) {
+         allowedRoot: String = NSHomeDirectory(),
+         nativeLookup: @escaping @Sendable (String, String) -> NativeCleaner? =
+            { NativeCleaner.available(for: $0, home: $1) },
+         nativeRunner: @escaping @Sendable (NativeCleaner) async -> ProcessResult = { native in
+            await ProcessRunner.run(native.binary, native.arguments,
+                                    timeout: native.timeout, environment: native.environment)
+         }) {
         self.catalog = catalog
         self.allowedRoot = allowedRoot
+        self.nativeLookup = nativeLookup
+        self.nativeRunner = nativeRunner
     }
 
     func load() {
@@ -62,10 +82,15 @@ final class CleanupController {
         lastFreed = 0
         lastFailures = 0
         lastRefused = 0
+        lastNativeIssues = []
         let detected = CleanupEngine.detect(catalog, allowedRoot: allowedRoot)
         // Keep existing selections across a refresh; drop ones that vanished.
         let previouslySelected = Set(rows.filter(\.selected).map(\.id))
-        rows = detected.map { Row(item: $0, selected: previouslySelected.contains($0.id)) }
+        rows = detected.map {
+            Row(item: $0,
+                nativeLabel: nativeLookup($0.id, allowedRoot)?.label,
+                selected: previouslySelected.contains($0.id))
+        }
         state = rows.isEmpty ? .ready : .sizing
         for item in detected {
             Task {
@@ -148,12 +173,20 @@ final class CleanupController {
 
         var failures = 0
         var refused = 0
+        var issues: [String] = []
         for item in targets {
-            let result = await Task.detached(priority: .userInitiated) {
-                CleanupEngine.clean(item, allowedRoot: root)
-            }.value
-            failures += result.failed
-            refused += result.refused
+            // Availability is resolved at clean time, not load time: the label
+            // shown is a promise, the decision here is the truth.
+            if let native = nativeLookup(item.id, root) {
+                let result = await nativeRunner(native)
+                if !result.ok { issues.append("\(item.name) — \(native.label): \(result.diagnostic)") }
+            } else {
+                let result = await Task.detached(priority: .userInitiated) {
+                    CleanupEngine.clean(item, allowedRoot: root)
+                }.value
+                failures += result.failed
+                refused += result.refused
+            }
             let measure = await Task.detached(priority: .userInitiated) {
                 CleanupEngine.size(of: item)
             }.value
@@ -163,6 +196,7 @@ final class CleanupController {
         if id == loadID { // results belong to the session that confirmed them
             lastFailures = failures
             lastRefused = refused
+            lastNativeIssues = issues
             lastFreed = max(0, before - totalSelected)
             for idx in rows.indices { rows[idx].selected = false }
         }
@@ -172,6 +206,8 @@ final class CleanupController {
             load()
         }
     }
+
+    func dismissNativeIssues() { lastNativeIssues = [] }
 
     // MARK: Private
 

--- a/Sources/SpaceMatters/ViewModel/CleanupController.swift
+++ b/Sources/SpaceMatters/ViewModel/CleanupController.swift
@@ -51,7 +51,7 @@ final class CleanupController {
         let id = loadID
         lastFreed = 0
         lastFailures = 0
-        let detected = CleanupEngine.detect(catalog)
+        let detected = CleanupEngine.detect(catalog, allowedRoot: allowedRoot)
         // Keep existing selections across a refresh; drop ones that vanished.
         let previouslySelected = Set(rows.filter(\.selected).map(\.id))
         rows = detected.map { Row(item: $0, selected: previouslySelected.contains($0.id)) }

--- a/Sources/SpaceMatters/ViewModel/CleanupController.swift
+++ b/Sources/SpaceMatters/ViewModel/CleanupController.swift
@@ -57,6 +57,9 @@ final class CleanupController {
     private let nativeLookup: @Sendable (String, String) -> NativeCleaner?
     private let nativeRunner: @Sendable (NativeCleaner) async -> ProcessResult
     private let blockedReason: @Sendable (String, String) -> String?
+    /// Called on the main actor with one entry per cleaned target — the
+    /// forensic trail behind field reports. Injectable so tests can collect.
+    private let journal: (CleanupJournal.Entry) -> Void
 
     /// `catalog`/`allowedRoot` are injectable so tests can run against fixtures;
     /// the app uses the built-in catalog fenced to the user's home.
@@ -72,12 +75,14 @@ final class CleanupController {
             id == "uv" && CleanupEngine.uvSymlinkMode(home: home)
                 ? "uv link-mode is \"symlink\" — cleaning would break your virtualenvs"
                 : nil
-         }) {
+         },
+         journal: @escaping (CleanupJournal.Entry) -> Void = { CleanupJournal.append($0) }) {
         self.catalog = catalog
         self.allowedRoot = allowedRoot
         self.nativeLookup = nativeLookup
         self.nativeRunner = nativeRunner
         self.blockedReason = blockedReason
+        self.journal = journal
     }
 
     func load() {
@@ -200,22 +205,36 @@ final class CleanupController {
         var failures = 0
         var refused = 0
         var issues: [String] = []
+        let active = ToolActivity.activeTools(for: Set(targets.map(\.id)))
         for item in targets {
+            var entry = CleanupJournal.Entry(
+                targetID: item.id, engine: "file", paths: item.paths,
+                bytesBefore: rows.first(where: { $0.id == item.id })?.size.bytes ?? 0)
+            entry.activeTools = active[item.id]?.sorted() ?? []
             // Availability is resolved at clean time, not load time: the label
             // shown is a promise, the decision here is the truth.
             if let native = nativeLookup(item.id, root) {
+                entry.engine = native.label
                 let result = await nativeRunner(native)
-                if !result.ok { issues.append("\(item.name) — \(native.label): \(result.diagnostic)") }
+                if !result.ok {
+                    entry.diagnostic = result.diagnostic
+                    issues.append("\(item.name) — \(native.label): \(result.diagnostic)")
+                }
             } else {
                 let result = await Task.detached(priority: .userInitiated) {
                     CleanupEngine.clean(item, allowedRoot: root)
                 }.value
+                entry.removed = result.removed
+                entry.failed = result.failed
+                entry.refused = result.refused
                 failures += result.failed
                 refused += result.refused
             }
             let measure = await Task.detached(priority: .userInitiated) {
                 CleanupEngine.size(of: item)
             }.value
+            if case .sized(let bytes) = measure { entry.bytesAfter = bytes }
+            journal(entry)
             if id == loadID { apply(measure, to: item.id) } // UI only — the batch continues
         }
 

--- a/Sources/SpaceMatters/ViewModel/CleanupController.swift
+++ b/Sources/SpaceMatters/ViewModel/CleanupController.swift
@@ -30,10 +30,16 @@ final class CleanupController {
     private(set) var lastFreed: Int64 = 0
     /// Children that could not be removed during the last clean (locked files…).
     private(set) var lastFailures = 0
+    /// Paths the safety fence refused during the last clean — a bug indicator
+    /// (detect and clean disagreeing), surfaced distinctly from plain failures.
+    private(set) var lastRefused = 0
 
     private let catalog: [Cleanable]
     private let allowedRoot: String
     private var loadID = 0 // invalidates in-flight sizing (same pattern as Kubernetes mode)
+    /// A reload asked for mid-clean is remembered and honoured when the batch
+    /// lands, instead of being dropped (or worse, resetting rows under it).
+    private var pendingReload = false
 
     /// `catalog`/`allowedRoot` are injectable so tests can run against fixtures;
     /// the app uses the built-in catalog fenced to the user's home.
@@ -45,12 +51,17 @@ final class CleanupController {
 
     func load() {
         // The model guards itself (same philosophy as DeletionGuardTests): a
-        // reload during a clean would reset rows/state under the operation.
-        guard state != .cleaning else { return }
+        // reload during a clean would reset rows/state under the operation —
+        // remember the intent and run it once the batch lands.
+        guard state != .cleaning else {
+            pendingReload = true
+            return
+        }
         loadID += 1
         let id = loadID
         lastFreed = 0
         lastFailures = 0
+        lastRefused = 0
         let detected = CleanupEngine.detect(catalog, allowedRoot: allowedRoot)
         // Keep existing selections across a refresh; drop ones that vanished.
         let previouslySelected = Set(rows.filter(\.selected).map(\.id))
@@ -68,7 +79,13 @@ final class CleanupController {
     }
 
     func refresh() { load() }
-    func stop() { loadID += 1 }
+    /// Leaving the mode detaches the UI from in-flight work (sizing results are
+    /// dropped, a running batch stops publishing) — it never aborts deletions
+    /// the user confirmed.
+    func stop() {
+        loadID += 1
+        pendingReload = false
+    }
 
     func toggle(_ id: String) {
         guard let idx = rows.firstIndex(where: { $0.id == id }) else { return }
@@ -116,7 +133,11 @@ final class CleanupController {
     // MARK: Cleaning
 
     /// Empty the selected targets, then re-size them so the freed bytes shown
-    /// are measured, not assumed. Only runs from `.ready` — never mid-sizing.
+    /// are measured, not assumed. Only starts from `.ready` — never mid-sizing.
+    /// A confirmed batch always runs to completion: leaving the mode detaches
+    /// the UI (`loadID` guards the writes), never the deletions, and the
+    /// controller always lands back on a terminal state — an abandoned
+    /// `.cleaning` would brick the mode (`load()` refuses under it).
     func cleanSelected() async {
         guard state == .ready, !selectedRows.isEmpty else { return }
         state = .cleaning
@@ -126,23 +147,30 @@ final class CleanupController {
         let root = allowedRoot
 
         var failures = 0
+        var refused = 0
         for item in targets {
             let result = await Task.detached(priority: .userInitiated) {
                 CleanupEngine.clean(item, allowedRoot: root)
             }.value
-            failures += result.failed + result.refused
+            failures += result.failed
+            refused += result.refused
             let measure = await Task.detached(priority: .userInitiated) {
                 CleanupEngine.size(of: item)
             }.value
-            guard id == loadID else { return } // mode left/re-entered mid-clean
-            apply(measure, to: item.id)
+            if id == loadID { apply(measure, to: item.id) } // UI only — the batch continues
         }
 
-        guard id == loadID else { return } // don't stamp a newer session's state
-        lastFailures = failures
-        lastFreed = max(0, before - totalSelected)
-        for idx in rows.indices { rows[idx].selected = false }
+        if id == loadID { // results belong to the session that confirmed them
+            lastFailures = failures
+            lastRefused = refused
+            lastFreed = max(0, before - totalSelected)
+            for idx in rows.indices { rows[idx].selected = false }
+        }
         state = .ready
+        if pendingReload {
+            pendingReload = false
+            load()
+        }
     }
 
     // MARK: Private

--- a/Sources/SpaceMatters/Views/CleanupResultView.swift
+++ b/Sources/SpaceMatters/Views/CleanupResultView.swift
@@ -10,6 +10,9 @@ struct CleanupResultView: View {
     @Environment(\.theme) private var theme
 
     @State private var confirmClean = false
+    /// Tools found running for the selected targets when Clean was pressed —
+    /// named in the confirmation so "my build failed" is never a surprise.
+    @State private var activeWarnings: [String: Set<String>] = [:]
 
     var body: some View {
         VStack(spacing: 0) {
@@ -46,8 +49,14 @@ struct CleanupResultView: View {
 
     private var confirmMessage: String {
         let names = controller.selectedRows.map(\.item.name).joined(separator: ", ")
-        return "\(names) — about \(Format.bytes(controller.totalSelected)) will be reclaimed. "
+        var message = "\(names) — about \(Format.bytes(controller.totalSelected)) will be reclaimed. "
             + "Caches are re-downloaded or rebuilt on demand; emptying the Trash is permanent."
+        let tools = activeWarnings.values.reduce(into: Set<String>()) { $0.formUnion($1) }
+        if !tools.isEmpty {
+            message += "\n\n⚠️ Running right now: \(tools.sorted().joined(separator: ", ")) — "
+                + "their in-progress builds or installs may fail."
+        }
+        return message
     }
 
     // MARK: Toolbar
@@ -208,7 +217,11 @@ struct CleanupResultView: View {
                     .font(.system(size: 11)).foregroundStyle(theme.textSecondary)
             }
             Spacer()
-            Button { confirmClean = true } label: {
+            Button {
+                activeWarnings = ToolActivity.activeTools(
+                    for: Set(controller.selectedRows.map(\.id)))
+                confirmClean = true
+            } label: {
                 Text(controller.totalSelected > 0
                      ? "Clean \(Format.bytes(controller.totalSelected))"
                      : "Clean")

--- a/Sources/SpaceMatters/Views/CleanupResultView.swift
+++ b/Sources/SpaceMatters/Views/CleanupResultView.swift
@@ -57,7 +57,12 @@ struct CleanupResultView: View {
     private var confirmMessage: String {
         let names = controller.selectedRows.map(\.item.name).joined(separator: ", ")
         var message = "\(names) — about \(Format.bytes(controller.totalSelected)) will be reclaimed. "
-            + "Caches are re-downloaded or rebuilt on demand; emptying the Trash is permanent."
+            + "Caches are re-downloaded or rebuilt on demand."
+        // The Trash is the one selected target that is user data, not a cache —
+        // its warning appears exactly when it applies, so it is never diluted.
+        if controller.selectedRows.contains(where: { $0.id == "trash" }) {
+            message += "\n\n⚠️ The Trash is not a cache: emptying it permanently deletes those files."
+        }
         let tools = activeWarnings.values.reduce(into: Set<String>()) { $0.formUnion($1) }
         if !tools.isEmpty {
             message += "\n\n⚠️ Running right now: \(tools.sorted().joined(separator: ", ")) — "
@@ -349,6 +354,11 @@ private struct CleanupRowView: View {
             }
             .buttonStyle(.plain)
             .help("Grant Full Disk Access to measure and clean this location")
+        case .blocked(let reason):
+            Label("Protected", systemImage: "exclamationmark.shield.fill")
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(Color(hex: 0xE0915A))
+                .help(reason)
         }
     }
 
@@ -357,6 +367,7 @@ private struct CleanupRowView: View {
         case .pending: return "measuring"
         case .sized(let bytes): return Format.bytes(bytes)
         case .denied: return "needs Full Disk Access"
+        case .blocked(let reason): return "protected: \(reason)"
         }
     }
 

--- a/Sources/SpaceMatters/Views/CleanupResultView.swift
+++ b/Sources/SpaceMatters/Views/CleanupResultView.swift
@@ -89,17 +89,25 @@ struct CleanupResultView: View {
                         subtitle: controller.state == .sizing ? "still measuring…" : "\(controller.rows.count) locations")
             summaryCard("Selected", value: Format.bytes(controller.totalSelected),
                         subtitle: "\(controller.selectedRows.count) of \(controller.rows.count)")
-            if controller.lastFreed > 0 {
+            // Shown as soon as a clean ran — a batch where everything failed
+            // must not hide its failures behind the absent card.
+            if controller.lastFreed > 0 || controller.lastFailures > 0 || controller.lastRefused > 0 {
                 summaryCard("Freed", value: Format.bytes(controller.lastFreed),
-                            subtitle: controller.lastFailures > 0
-                                ? "\(controller.lastFailures) items couldn't be removed"
-                                : "measured after cleaning",
-                            accent: true)
+                            subtitle: freedSubtitle, accent: true)
             }
             Spacer()
         }
         .padding(.horizontal, 14).padding(.vertical, 8)
         .background(theme.panelBackground)
+    }
+
+    /// Failures (in use, locked) and fence refusals (a bug indicator) are
+    /// different stories — never fold one into the other.
+    private var freedSubtitle: String {
+        var parts: [String] = []
+        if controller.lastFailures > 0 { parts.append("\(controller.lastFailures) in use or locked") }
+        if controller.lastRefused > 0 { parts.append("\(controller.lastRefused) skipped by the safety fence") }
+        return parts.isEmpty ? "measured after cleaning" : parts.joined(separator: " · ")
     }
 
     private func summaryCard(_ title: String, value: String, subtitle: String, accent: Bool = false) -> some View {

--- a/Sources/SpaceMatters/Views/CleanupResultView.swift
+++ b/Sources/SpaceMatters/Views/CleanupResultView.swift
@@ -45,6 +45,13 @@ struct CleanupResultView: View {
         } message: {
             Text(confirmMessage)
         }
+        .alert("A cleaner reported a problem", isPresented: Binding(
+            get: { !controller.lastNativeIssues.isEmpty },
+            set: { if !$0 { controller.dismissNativeIssues() } })) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(controller.lastNativeIssues.joined(separator: "\n"))
+        }
     }
 
     private var confirmMessage: String {
@@ -297,6 +304,15 @@ private struct CleanupRowView: View {
                 .foregroundStyle(theme.textSecondary)
                 .lineLimit(1)
                 .layoutPriority(1)
+
+            if let native = row.nativeLabel {
+                Text("via \(native)")
+                    .font(.system(size: 9, weight: .medium))
+                    .foregroundStyle(theme.accent.opacity(0.85))
+                    .padding(.horizontal, 5).padding(.vertical, 1)
+                    .background(Capsule().fill(theme.accent.opacity(0.12)))
+                    .layoutPriority(1)
+            }
 
             Spacer(minLength: 8)
 

--- a/Tests/SpaceMattersTests/CleanupTests.swift
+++ b/Tests/SpaceMattersTests/CleanupTests.swift
@@ -287,6 +287,37 @@ import Foundation
         #expect(c.totalFound == 0) // …and the emptied cache re-measured at zero
     }
 
+    /// When a native cleaner is available the vendor's tool runs and the file
+    /// engine never touches the cache; a non-zero exit is surfaced, not
+    /// silently retried as file removal (the failure may be the vendor's lock
+    /// doing its job).
+    @Test func nativeCleanerReplacesFileRemovalAndSurfacesFailure() async throws {
+        let (root, cache) = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let fake = NativeCleaner(binary: "/usr/bin/false", arguments: [],
+                                 environment: [:], timeout: 5, label: "fake prune")
+        let calls = CallCounter()
+        let c = CleanupController(
+            catalog: [Self.cleanable([cache.path])], allowedRoot: root.path,
+            nativeLookup: { id, _ in id == "test-cache" ? fake : nil },
+            nativeRunner: { _ in
+                await calls.bump()
+                return ProcessResult(stdout: Data(), stderr: Data("store is busy".utf8),
+                                     exitCode: 1, timedOut: false)
+            })
+        c.load()
+        await Self.waitForReady(c)
+        #expect(c.rows.first?.nativeLabel == "fake prune")
+
+        c.toggle("test-cache")
+        await c.cleanSelected()
+
+        #expect(await calls.count == 1)
+        #expect(FileManager.default.fileExists(atPath: cache.appendingPathComponent("a.bin").path))
+        #expect(c.lastNativeIssues == ["Test cache — fake prune: store is busy"])
+        #expect(c.state == .ready)
+    }
+
     /// Entries whose paths don't exist disappear; existing ones keep only their
     /// existing paths.
     @Test func detectFiltersMissingPaths() throws {
@@ -349,4 +380,10 @@ import Foundation
 
         #expect(CleanupEngine.size(of: Self.cleanable([link.path])) == .denied)
     }
+}
+
+/// Serialized call counter usable from `@Sendable` closures in tests.
+private actor CallCounter {
+    private(set) var count = 0
+    func bump() { count += 1 }
 }

--- a/Tests/SpaceMattersTests/CleanupTests.swift
+++ b/Tests/SpaceMattersTests/CleanupTests.swift
@@ -241,8 +241,56 @@ import Foundation
             Self.cleanable([cache.path, ghost]),
             Cleanable(id: "ghost", name: "Ghost", category: "Test",
                       icon: "shippingbox", note: "", paths: [ghost]),
-        ])
+        ], allowedRoot: root.path)
         #expect(detected.count == 1)
         #expect(detected[0].paths == [cache.path])
+    }
+
+    /// A symlinked cache root is excluded at detection time — the row never
+    /// appears, instead of being sized through the link and refused at cleaning
+    /// time with gigabytes left on screen.
+    @Test func detectRefusesSymlinkedRoot() throws {
+        let (root, _) = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let outside = FileManager.default.temporaryDirectory
+            .appendingPathComponent("sm-detect-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: outside) }
+        try FileManager.default.createDirectory(at: outside, withIntermediateDirectories: true)
+        let link = root.appendingPathComponent("linked-cache")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: outside)
+
+        let detected = CleanupEngine.detect([Self.cleanable([link.path])], allowedRoot: root.path)
+        #expect(detected.isEmpty)
+    }
+
+    /// detect applies the same resolved-fence rule as clean: a path that passes
+    /// the textual prefix but resolves outside the fence is never offered.
+    @Test func detectRefusesRelocatedIntermediateComponent() throws {
+        let fm = FileManager.default
+        let base = fm.temporaryDirectory.appendingPathComponent("sm-detect-fence-\(UUID().uuidString)")
+        let home = base.appendingPathComponent("home")
+        let external = base.appendingPathComponent("external/gradle")
+        try fm.createDirectory(at: home, withIntermediateDirectories: true)
+        try fm.createDirectory(at: external.appendingPathComponent("caches"), withIntermediateDirectories: true)
+        try fm.createSymbolicLink(at: home.appendingPathComponent(".gradle"), withDestinationURL: external)
+        defer { try? fm.removeItem(at: base) }
+
+        let target = home.appendingPathComponent(".gradle/caches").path
+        let detected = CleanupEngine.detect([Self.cleanable([target])], allowedRoot: home.path)
+        #expect(detected.isEmpty)
+    }
+
+    /// size never measures through a symlinked root — denied, consistently with
+    /// what detect and clean decide, even when called directly.
+    @Test func sizeIsDeniedOnSymlinkedRoot() throws {
+        let (root, _) = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let victim = root.appendingPathComponent("victim")
+        try FileManager.default.createDirectory(at: victim, withIntermediateDirectories: true)
+        try Data(count: 4096).write(to: victim.appendingPathComponent("keep.bin"))
+        let link = root.appendingPathComponent("linked-cache")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: victim)
+
+        #expect(CleanupEngine.size(of: Self.cleanable([link.path])) == .denied)
     }
 }

--- a/Tests/SpaceMattersTests/CleanupTests.swift
+++ b/Tests/SpaceMattersTests/CleanupTests.swift
@@ -33,6 +33,13 @@ import Foundation
         }
     }
 
+    static func waitForCleaning(_ c: CleanupController, timeout: TimeInterval = 5) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while c.state != .cleaning && Date() < deadline {
+            await Task.yield()
+        }
+    }
+
     // MARK: Catalog
 
     @Test func catalogStaysInsideHome() {
@@ -229,6 +236,55 @@ import Foundation
         c.toggleAll() // all → none
         #expect(c.selectAllState == .none)
         #expect(c.selectedRows.isEmpty)
+    }
+
+    /// A confirmed batch survives leaving the mode: every deletion runs to
+    /// completion, only the UI writes are dropped, and the controller lands
+    /// back on a terminal state instead of a forever-`.cleaning` brick.
+    @Test func stopMidCleanCompletesBatchAndRestoresState() async throws {
+        let (root, cache) = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let cache2 = root.appendingPathComponent("cache2")
+        try FileManager.default.createDirectory(at: cache2, withIntermediateDirectories: true)
+        try Data(count: 4096).write(to: cache2.appendingPathComponent("c.bin"))
+        let second = Cleanable(id: "test-cache-2", name: "Second cache", category: "Test",
+                               icon: "shippingbox", note: "fixture", paths: [cache2.path])
+        let c = CleanupController(catalog: [Self.cleanable([cache.path]), second],
+                                  allowedRoot: root.path)
+        c.load()
+        await Self.waitForReady(c)
+        c.toggleAll()
+
+        let batch = Task { await c.cleanSelected() }
+        await Self.waitForCleaning(c)
+        c.stop() // user leaves the mode right after confirming
+        await batch.value
+
+        #expect(c.state == .ready)
+        #expect(try FileManager.default.contentsOfDirectory(atPath: cache.path).isEmpty)
+        #expect(try FileManager.default.contentsOfDirectory(atPath: cache2.path).isEmpty)
+        #expect(c.lastFreed == 0) // results are never stamped on a session that left
+    }
+
+    /// A reload asked for mid-clean (mode re-entered) is deferred, not dropped:
+    /// the batch is left untouched and fresh rows appear once it lands.
+    @Test func reloadDuringCleanIsDeferredUntilBatchEnds() async throws {
+        let (root, cache) = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let c = CleanupController(catalog: [Self.cleanable([cache.path])], allowedRoot: root.path)
+        c.load()
+        await Self.waitForReady(c)
+        c.toggle("test-cache")
+
+        let batch = Task { await c.cleanSelected() }
+        await Self.waitForCleaning(c)
+        c.load() // re-entering the mode mid-batch
+        #expect(c.state == .cleaning) // rows/state untouched under the operation
+
+        await batch.value
+        await Self.waitForReady(c)
+        #expect(c.rows.count == 1) // deferred reload ran: fresh detection…
+        #expect(c.totalFound == 0) // …and the emptied cache re-measured at zero
     }
 
     /// Entries whose paths don't exist disappear; existing ones keep only their

--- a/Tests/SpaceMattersTests/CleanupTests.swift
+++ b/Tests/SpaceMattersTests/CleanupTests.swift
@@ -286,8 +286,10 @@ import Foundation
 
         await batch.value
         await Self.waitForReady(c)
-        #expect(c.rows.count == 1) // deferred reload ran: fresh detection…
-        #expect(c.totalFound == 0) // …and the emptied cache re-measured at zero
+        // The deferred reload ran as a *fresh* load: the cache the batch just
+        // emptied re-measures at 0 B and is dropped by the empty-row rule.
+        #expect(c.rows.isEmpty)
+        #expect(c.totalFound == 0)
     }
 
     /// When a native cleaner is available the vendor's tool runs and the file
@@ -434,6 +436,34 @@ import Foundation
         let decoded = try decoder.decode(CleanupJournal.Entry.self, from: Data(lines[0].utf8))
         #expect(decoded.targetID == "npm")
         #expect(decoded.bytesBefore == 42)
+    }
+
+    /// An empty cache on the initial sizing pass is dropped — nothing to
+    /// reclaim, the row is noise (the file engine keeps cache roots alive, so
+    /// empties are common after a past clean). A row cleaned to 0 B in-session
+    /// stays visible: that 0 is the result the user just paid for.
+    @Test func emptyRowsAreDroppedOnLoadButKeptAfterCleaning() async throws {
+        let (root, cache) = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let empty = root.appendingPathComponent("empty-cache")
+        try FileManager.default.createDirectory(at: empty, withIntermediateDirectories: true)
+        let emptyItem = Cleanable(id: "empty-cache", name: "Empty", category: "Test",
+                                  icon: "shippingbox", note: "fixture", paths: [empty.path])
+        let c = CleanupController(catalog: [Self.cleanable([cache.path]), emptyItem],
+                                  allowedRoot: root.path, journal: { _ in })
+        c.load()
+        await Self.waitForReady(c)
+        #expect(c.rows.map(\.id) == ["test-cache"]) // the empty row never appears
+
+        c.toggle("test-cache")
+        await c.cleanSelected()
+        #expect(c.rows.map(\.id) == ["test-cache"]) // still there, showing its result…
+        #expect(c.rows.first?.size == .sized(0))    // …which is 0 B
+
+        c.refresh() // next reload applies the fresh-load rule again
+        await Self.waitForReady(c)
+        #expect(c.rows.isEmpty)
+        #expect(c.state == .ready)
     }
 
     /// Entries whose paths don't exist disappear; existing ones keep only their

--- a/Tests/SpaceMattersTests/CleanupTests.swift
+++ b/Tests/SpaceMattersTests/CleanupTests.swift
@@ -386,6 +386,51 @@ import Foundation
         #expect(CleanupEngine.uvSymlinkMode(home: home.path, environment: [:]) == false)
     }
 
+    /// Every cleaned target leaves a journal entry: engine, sizes before and
+    /// after, and per-child outcome — the forensic trail for field reports.
+    @Test func cleanJournalsEachTarget() async throws {
+        let (root, cache) = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let box = JournalBox()
+        let c = CleanupController(catalog: [Self.cleanable([cache.path])],
+                                  allowedRoot: root.path,
+                                  journal: { box.entries.append($0) })
+        c.load()
+        await Self.waitForReady(c)
+        c.toggle("test-cache")
+        await c.cleanSelected()
+
+        #expect(box.entries.count == 1)
+        let entry = try #require(box.entries.first)
+        #expect(entry.targetID == "test-cache")
+        #expect(entry.engine == "file")
+        #expect(entry.paths == [cache.path])
+        #expect(entry.bytesBefore >= 150_000)
+        #expect(entry.bytesAfter == 0)
+        #expect(entry.removed == 2 && entry.failed == 0 && entry.refused == 0)
+    }
+
+    /// The journal file is append-only JSONL, one decodable entry per line.
+    @Test func journalAppendsDecodableLines() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("sm-journal-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let entry = CleanupJournal.Entry(targetID: "npm", engine: "file",
+                                         paths: ["/x"], bytesBefore: 42)
+        CleanupJournal.append(entry, directory: dir)
+        CleanupJournal.append(entry, directory: dir)
+
+        let text = try String(contentsOf: dir.appendingPathComponent("cleanup.jsonl"),
+                              encoding: .utf8)
+        let lines = text.split(separator: "\n")
+        #expect(lines.count == 2)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(CleanupJournal.Entry.self, from: Data(lines[0].utf8))
+        #expect(decoded.targetID == "npm")
+        #expect(decoded.bytesBefore == 42)
+    }
+
     /// Entries whose paths don't exist disappear; existing ones keep only their
     /// existing paths.
     @Test func detectFiltersMissingPaths() throws {
@@ -454,4 +499,10 @@ import Foundation
 private actor CallCounter {
     private(set) var count = 0
     func bump() { count += 1 }
+}
+
+/// Journal collector — the controller calls it on the main actor.
+@MainActor
+private final class JournalBox {
+    var entries: [CleanupJournal.Entry] = []
 }

--- a/Tests/SpaceMattersTests/CleanupTests.swift
+++ b/Tests/SpaceMattersTests/CleanupTests.swift
@@ -174,7 +174,8 @@ import Foundation
     @Test func controllerSizesSelectsAndCleans() async throws {
         let (root, cache) = try Self.makeFixture()
         defer { try? FileManager.default.removeItem(at: root) }
-        let c = CleanupController(catalog: [Self.cleanable([cache.path])], allowedRoot: root.path)
+        let c = CleanupController(catalog: [Self.cleanable([cache.path])], allowedRoot: root.path,
+                                  journal: { _ in }) // fixtures must never write the user's journal
         c.load()
         await Self.waitForReady(c)
 
@@ -196,7 +197,8 @@ import Foundation
     @Test func cleanRefusedWhileSizing() async throws {
         let (root, cache) = try Self.makeFixture()
         defer { try? FileManager.default.removeItem(at: root) }
-        let c = CleanupController(catalog: [Self.cleanable([cache.path])], allowedRoot: root.path)
+        let c = CleanupController(catalog: [Self.cleanable([cache.path])], allowedRoot: root.path,
+                                  journal: { _ in }) // fixtures must never write the user's journal
         c.load()
         #expect(c.state == .sizing)
 
@@ -220,7 +222,7 @@ import Foundation
         let second = Cleanable(id: "test-cache-2", name: "Second cache", category: "Test",
                                icon: "shippingbox", note: "fixture", paths: [cache2.path])
         let c = CleanupController(catalog: [Self.cleanable([cache.path]), second],
-                                  allowedRoot: root.path)
+                                  allowedRoot: root.path, journal: { _ in })
         c.load()
         await Self.waitForReady(c)
 
@@ -250,7 +252,7 @@ import Foundation
         let second = Cleanable(id: "test-cache-2", name: "Second cache", category: "Test",
                                icon: "shippingbox", note: "fixture", paths: [cache2.path])
         let c = CleanupController(catalog: [Self.cleanable([cache.path]), second],
-                                  allowedRoot: root.path)
+                                  allowedRoot: root.path, journal: { _ in })
         c.load()
         await Self.waitForReady(c)
         c.toggleAll()
@@ -271,7 +273,8 @@ import Foundation
     @Test func reloadDuringCleanIsDeferredUntilBatchEnds() async throws {
         let (root, cache) = try Self.makeFixture()
         defer { try? FileManager.default.removeItem(at: root) }
-        let c = CleanupController(catalog: [Self.cleanable([cache.path])], allowedRoot: root.path)
+        let c = CleanupController(catalog: [Self.cleanable([cache.path])], allowedRoot: root.path,
+                                  journal: { _ in }) // fixtures must never write the user's journal
         c.load()
         await Self.waitForReady(c)
         c.toggle("test-cache")
@@ -304,7 +307,8 @@ import Foundation
                 await calls.bump()
                 return ProcessResult(stdout: Data(), stderr: Data("store is busy".utf8),
                                      exitCode: 1, timedOut: false)
-            })
+            },
+            journal: { _ in })
         c.load()
         await Self.waitForReady(c)
         #expect(c.rows.first?.nativeLabel == "fake prune")
@@ -329,7 +333,7 @@ import Foundation
         let trash = Cleanable(id: "trash", name: "Trash", category: "System",
                               icon: "trash.fill", note: "fixture", paths: [trashDir.path])
         let c = CleanupController(catalog: [Self.cleanable([cache.path]), trash],
-                                  allowedRoot: root.path)
+                                  allowedRoot: root.path, journal: { _ in })
         c.load()
         await Self.waitForReady(c)
 
@@ -350,7 +354,8 @@ import Foundation
         defer { try? FileManager.default.removeItem(at: root) }
         let c = CleanupController(
             catalog: [Self.cleanable([cache.path])], allowedRoot: root.path,
-            blockedReason: { id, _ in id == "test-cache" ? "would break venvs" : nil })
+            blockedReason: { id, _ in id == "test-cache" ? "would break venvs" : nil },
+            journal: { _ in })
         c.load()
         await Self.waitForReady(c)
 
@@ -480,9 +485,50 @@ import Foundation
         #expect(detected.isEmpty)
     }
 
-    /// size never measures through a symlinked root — denied, consistently with
-    /// what detect and clean decide, even when called directly.
-    @Test func sizeIsDeniedOnSymlinkedRoot() throws {
+    /// A cache root removed by its native cleaner (dotnet deletes its folders
+    /// outright) is *empty*, not "Needs access": ENOENT and EACCES are
+    /// different stories. First field catch of the operation journal.
+    @Test func vanishedRootSizesAsZeroNotDenied() throws {
+        let (root, cache) = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let gone = root.appendingPathComponent("vanished").path
+        #expect(CleanupEngine.size(of: Self.cleanable([gone])) == .sized(0))
+
+        // Mixed: the existing path still measures, the vanished one adds nothing.
+        guard case .sized(let bytes) = CleanupEngine.size(of: Self.cleanable([cache.path, gone])) else {
+            Issue.record("expected .sized for a mixed existing+vanished item")
+            return
+        }
+        #expect(bytes >= 150_000)
+    }
+
+    /// An unreadable root (permissions) still reads as denied — that is the
+    /// case the "Needs access" row is for.
+    @Test func unreadableRootStaysDenied() throws {
+        let (root, cache) = try Self.makeFixture()
+        defer {
+            chmod(cache.path, 0o755)
+            try? FileManager.default.removeItem(at: root)
+        }
+        chmod(cache.path, 0o000)
+        #expect(CleanupEngine.size(of: Self.cleanable([cache.path])) == .denied)
+    }
+
+    /// clean() on a vanished root reports nothing at all — neither a failure
+    /// nor a fence refusal; there is simply nothing to do.
+    @Test func cleanTreatsVanishedRootAsNoop() throws {
+        let (root, _) = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let gone = root.appendingPathComponent("vanished").path
+        let result = CleanupEngine.clean(Self.cleanable([gone]), allowedRoot: root.path)
+        #expect(result == CleanupEngine.CleanResult())
+    }
+
+    /// size never measures through a symlinked root (ELOOP under O_NOFOLLOW).
+    /// detect excludes it anyway; a direct call answers "nothing cleanable
+    /// here" (0 B) — not "needs access", which would send the user to grant
+    /// Full Disk Access for a relocated cache.
+    @Test func sizeNeverMeasuresThroughSymlinkedRoot() throws {
         let (root, _) = try Self.makeFixture()
         defer { try? FileManager.default.removeItem(at: root) }
         let victim = root.appendingPathComponent("victim")
@@ -491,7 +537,7 @@ import Foundation
         let link = root.appendingPathComponent("linked-cache")
         try FileManager.default.createSymbolicLink(at: link, withDestinationURL: victim)
 
-        #expect(CleanupEngine.size(of: Self.cleanable([link.path])) == .denied)
+        #expect(CleanupEngine.size(of: Self.cleanable([link.path])) == .sized(0))
     }
 }
 

--- a/Tests/SpaceMattersTests/CleanupTests.swift
+++ b/Tests/SpaceMattersTests/CleanupTests.swift
@@ -318,6 +318,74 @@ import Foundation
         #expect(c.state == .ready)
     }
 
+    /// The Trash is user data, not a cache: the select-all header ignores it in
+    /// both directions — it is only ever selected row by row.
+    @Test func selectAllNeverTouchesTheTrash() async throws {
+        let (root, cache) = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let trashDir = root.appendingPathComponent(".Trash")
+        try FileManager.default.createDirectory(at: trashDir, withIntermediateDirectories: true)
+        try Data(count: 4096).write(to: trashDir.appendingPathComponent("t.bin"))
+        let trash = Cleanable(id: "trash", name: "Trash", category: "System",
+                              icon: "trash.fill", note: "fixture", paths: [trashDir.path])
+        let c = CleanupController(catalog: [Self.cleanable([cache.path]), trash],
+                                  allowedRoot: root.path)
+        c.load()
+        await Self.waitForReady(c)
+
+        c.toggleAll()
+        #expect(c.selectAllState == .all) // all *cache* rows selected…
+        #expect(c.selectedRows.map(\.id) == ["test-cache"]) // …Trash left alone
+
+        c.toggle("trash") // explicit per-row opt-in still works
+        #expect(c.selectedRows.count == 2)
+        c.toggleAll() // all → none clears caches, not the hand-picked Trash
+        #expect(c.selectedRows.map(\.id) == ["trash"])
+    }
+
+    /// A blocked target (uv in link-mode=symlink) is shown but never sized,
+    /// never selectable — and a stale selection doesn't survive into it.
+    @Test func blockedRowIsVisibleButInert() async throws {
+        let (root, cache) = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let c = CleanupController(
+            catalog: [Self.cleanable([cache.path])], allowedRoot: root.path,
+            blockedReason: { id, _ in id == "test-cache" ? "would break venvs" : nil })
+        c.load()
+        await Self.waitForReady(c)
+
+        #expect(c.rows.first?.size == .blocked("would break venvs"))
+        c.toggle("test-cache") // the model refuses, not just the disabled checkbox
+        c.toggleAll()
+        #expect(c.selectedRows.isEmpty)
+        #expect(c.state == .ready) // an all-blocked catalog still settles
+
+        await c.cleanSelected()
+        #expect(FileManager.default.fileExists(atPath: cache.appendingPathComponent("a.bin").path))
+    }
+
+    /// The uv guard reads the environment and uv's user-level config.
+    @Test func uvSymlinkModeDetection() throws {
+        #expect(CleanupEngine.uvSymlinkMode(home: "/nonexistent", environment: [:]) == false)
+        #expect(CleanupEngine.uvSymlinkMode(home: "/nonexistent",
+                                            environment: ["UV_LINK_MODE": "symlink"]))
+        #expect(CleanupEngine.uvSymlinkMode(home: "/nonexistent",
+                                            environment: ["UV_LINK_MODE": "hardlink"]) == false)
+
+        let fm = FileManager.default
+        let home = fm.temporaryDirectory.appendingPathComponent("sm-uv-\(UUID().uuidString)")
+        defer { try? fm.removeItem(at: home) }
+        let configDir = home.appendingPathComponent(".config/uv")
+        try fm.createDirectory(at: configDir, withIntermediateDirectories: true)
+        try #"link-mode = "symlink""#.write(
+            to: configDir.appendingPathComponent("uv.toml"), atomically: true, encoding: .utf8)
+        #expect(CleanupEngine.uvSymlinkMode(home: home.path, environment: [:]))
+
+        try #"# link-mode = "symlink""#.write(
+            to: configDir.appendingPathComponent("uv.toml"), atomically: true, encoding: .utf8)
+        #expect(CleanupEngine.uvSymlinkMode(home: home.path, environment: [:]) == false)
+    }
+
     /// Entries whose paths don't exist disappear; existing ones keep only their
     /// existing paths.
     @Test func detectFiltersMissingPaths() throws {

--- a/Tests/SpaceMattersTests/NativeCleanerTests.swift
+++ b/Tests/SpaceMattersTests/NativeCleanerTests.swift
@@ -1,0 +1,43 @@
+import Testing
+import Foundation
+@testable import SpaceMatters
+
+/// Native cleaner resolution: which targets get one, which binary wins, and
+/// the hygiene environment they run under. Execution is never exercised here —
+/// the controller seam is tested in `CleanupTests`.
+struct NativeCleanerTests {
+
+    @Test func picksTheFirstExistingCandidate() {
+        let native = NativeCleaner.available(
+            for: "homebrew", home: "/tmp/h",
+            isExecutable: { $0 == "/usr/local/bin/brew" })
+        #expect(native?.binary == "/usr/local/bin/brew")
+        #expect(native?.label == "brew cleanup")
+        #expect(native?.arguments == ["cleanup", "-s", "--prune=all"])
+    }
+
+    /// npm/pip/yarn… deliberately have no native cleaner (their caches are
+    /// designed for plain removal); a known target without its binary has none
+    /// either — the file engine is the fallback in both cases.
+    @Test func fileEngineTargetsAndMissingBinariesResolveToNil() {
+        #expect(NativeCleaner.available(for: "npm", isExecutable: { _ in true }) == nil)
+        #expect(NativeCleaner.available(for: "trash", isExecutable: { _ in true }) == nil)
+        #expect(NativeCleaner.available(for: "homebrew", isExecutable: { _ in false }) == nil)
+    }
+
+    @Test func brewRunsWithHygieneEnvironment() {
+        let native = NativeCleaner.available(for: "homebrew", isExecutable: { _ in true })
+        #expect(native?.environment["HOMEBREW_NO_AUTO_UPDATE"] == "1")
+        #expect(native?.environment["HOMEBREW_NO_ANALYTICS"] == "1")
+    }
+
+    /// pnpm's standalone install lives under the user's home — the candidate
+    /// list must follow the injected home, not the test runner's.
+    @Test func pnpmProbesTheHomeShim() {
+        let native = NativeCleaner.available(
+            for: "pnpm", home: "/Users/x",
+            isExecutable: { $0 == "/Users/x/Library/pnpm/pnpm" })
+        #expect(native?.binary == "/Users/x/Library/pnpm/pnpm")
+        #expect(native?.arguments == ["store", "prune"])
+    }
+}

--- a/Tests/SpaceMattersTests/ToolActivityTests.swift
+++ b/Tests/SpaceMattersTests/ToolActivityTests.swift
@@ -1,0 +1,35 @@
+import Testing
+@testable import SpaceMatters
+
+/// The active-tool warnings behind the cleanup confirmation dialog: the pure
+/// classification table, the JVM disambiguation, and a smoke run of the
+/// sysctl plumbing (content is machine-dependent, crashing is not).
+struct ToolActivityTests {
+
+    @Test func classifiesKnownComms() {
+        #expect(ToolActivity.classify(comm: "brew", argv: []).map(\.target) == ["homebrew"])
+        #expect(Set(ToolActivity.classify(comm: "Xcode", argv: []).map(\.target))
+            == Set(["derived-data", "swiftpm"]))
+        #expect(ToolActivity.classify(comm: "go", argv: []).map(\.target) == ["go-build"])
+        #expect(ToolActivity.classify(comm: "Safari", argv: []).isEmpty)
+    }
+
+    @Test func classifiesJVMsByArguments() {
+        let daemon = ToolActivity.classify(
+            comm: "java",
+            argv: ["java", "-Xmx2g", "org.gradle.launcher.daemon.bootstrap.GradleDaemon", "8.7"])
+        #expect(daemon.map(\.target) == ["gradle"])
+        #expect(daemon.map(\.tool) == ["a Gradle daemon"])
+
+        let maven = ToolActivity.classify(
+            comm: "java",
+            argv: ["java", "-classpath", "/x", "org.codehaus.plexus.classworlds.launcher.Launcher"])
+        #expect(maven.map(\.target) == ["maven"])
+
+        #expect(ToolActivity.classify(comm: "java", argv: ["java", "-jar", "app.jar"]).isEmpty)
+    }
+
+    @Test func activeToolsSmoke() {
+        _ = ToolActivity.activeTools(for: ["homebrew", "gradle", "npm"])
+    }
+}


### PR DESCRIPTION
Follow-up to a field report ("cleaned my brew cache, my Docker install broke") and the targeted audit it triggered (report in local `docs/audit/`). The audit exonerated symlink traversal (`removeItem` never follows links at any depth, verified empirically) and identified the credible mechanism instead: cleaning a cache while its tool is mid-operation, with the uninstall→reinstall window of `brew upgrade --cask` as the damaging case. This PR closes that class and the audit's other findings.

## Major fixes

- **M1, active-tool awareness.** `ToolActivity` lists same-uid processes (one sysctl, `p_comm` matching, argv read only to tell Gradle daemons and Maven apart from other JVMs) and the confirmation dialog names what is running (for example Xcode and a Gradle daemon, warning that in-progress builds may fail). A warning, not a lock.
- **Native cleaners where the vendor has irreplaceable semantics.** brew (`cleanup -s --prune=all`, which coordinates through Homebrew's own locks and closes the destructive race structurally), pnpm (`store prune`, unreferenced packages only), NuGet (`dotnet nuget locals all --clear`), Go (`go clean -cache`). Fixed-prefix binary discovery (GUI apps inherit no shell PATH), hygiene env, 10 minute deadline under the ProcessRunner watchdog. A native failure is surfaced and never retried as file removal, and rows show a "via brew cleanup" badge. Lookup and runner are injectable, so tests never spawn real tools.
- **M2, batch lifecycle.** A confirmed batch now runs to completion, and `loadID` only guards UI writes. Previously, leaving the mode mid-clean left `state == .cleaning` forever (mode bricked until restart) and silently dropped the rest of the confirmed batch. Reloads asked mid-batch are remembered and replayed.
- **M3, fence coherence.** The full fence (textual prefix, `lstat`, resolved path) is decided once at `detect` time and shared with `clean`: a symlinked or relocated cache root is never shown, sized through its link, then refused with phantom gigabytes on screen. `size()` opens everything `O_NOFOLLOW`, `clean()` skips volumes mounted inside a cache, and fence refusals surface separately from locked-file failures.
- **M4, honest catalog.** Maven's note names the `install:install-file` exception (those JARs never come back), NuGet mentions feed access, and uv in `link-mode=symlink` (where wiping the cache breaks every venv, per uv's own docs) is detected (env plus `uv.toml`) and shown as a protected, unselectable row.

## Honesty and forensics

- **Trash out of select-all.** The one target that is user data, not a cache, is now selected row by row only, and its permanence warning appears in the confirmation exactly when it applies.
- **Operation journal** (`~/Library/Logs/SpaceMatters/cleanup.jsonl`): one JSONL entry per cleaned target, recording engine, paths, bytes before and after, outcome, and the tools active at clean time. The original field report was undecidable for lack of exactly this.
- **First field catch, same day:** the journal's first real use showed `dotnet nuget locals --clear` succeeding (6.9 GB freed) while deleting its cache directories outright, after which `size()` reported the missing roots as "Needs access". `size()` is now errno-aware (EACCES/EPERM means denied, ENOENT/ELOOP means 0 B) and `clean()` treats a vanished root as a no-op.
- **Empty rows do not earn a place on load** (the file engine keeps cache roots alive by design), but a row cleaned to 0 B in-session stays visible as the result until the next reload.

## Verification

- 102 tests green (15 suites, 17 new: fence counter-examples, batch lifecycle, tool classification, native seams, uv guard, journal, empty-row rule). Test fixtures inject a silent journal, as they had been appending to the user's real one.
- Release build plus SwiftLint clean, exercised end to end on a real machine: native brew, dotnet and go paths taken, 13.8 GiB reclaimed, journal readable, select-all leaves Trash alone.

Deferred (documented): nlink-aware freed sizing for shared stores, multi-volume Trash, per-path denied signal, read-only native path queries for env-overridden caches.
