### PR TITLE
fix(banner): latch the drift reason so the disk-changed banner stops flapping

### DIFF
--- a/Sources/SpaceMatters/ViewModel/ScanController.swift
+++ b/Sources/SpaceMatters/ViewModel/ScanController.swift
@@ -255,6 +255,15 @@ final class ScanController {
     /// something changed that the watcher didn't see (another user, an
     /// unscannable area…). Above the budget, the banner proposes a Refresh.
     private(set) var driftBytes: Int64 = 0
+    /// The drift reason currently holds the banner up (see `updateDriftLatch`).
+    @ObservationIgnored private var driftLatched = false
+    /// When the drift first crossed the budget without falling back under it.
+    @ObservationIgnored private var driftOverBudgetSince: Date?
+    @ObservationIgnored private var driftSettleScheduled = false
+    /// How long an unexplained drift must hold before it's worth a banner —
+    /// long enough to outlive a reconcile cycle and APFS's lazy free-space
+    /// accounting. Instance-level so tests don't have to wait it out.
+    @ObservationIgnored var driftSettleDelay: TimeInterval = 5
 
     /// Record a physical-bytes change the tree now reflects (either sign).
     private func noteAppliedPhysical(_ delta: Int64) {
@@ -269,6 +278,8 @@ final class ScanController {
         appliedPhysicalDelta = 0
         changedBytes = 0
         driftBytes = 0
+        driftLatched = false
+        driftOverBudgetSince = nil
     }
 
     @ObservationIgnored private var reconcileRunning = false
@@ -1201,6 +1212,8 @@ final class ScanController {
         diskChanged = false
         changedBytes = 0
         driftBytes = 0
+        driftLatched = false
+        driftOverBudgetSince = nil
         appliedPhysicalDelta = 0
         baselineFreeBytes = nil
     }
@@ -1256,11 +1269,79 @@ final class ScanController {
     /// pending to explain it). Ordinary changes reconcile silently — the map
     /// just breathes.
     private func updateBannerState() {
-        let unexplained = dirtyNeeds.isEmpty && abs(driftBytes) >= diskChangeBudget
-        let show = watchRootChanged || !pendingConsentPaths.isEmpty || unexplained
+        updateDriftLatch()
+        let show = watchRootChanged || !pendingConsentPaths.isEmpty || driftLatched
         if show != diskChanged {
             diskChanged = show
             bump()
+        }
+    }
+
+    /// The drift condition is sampled twice per cycle — on every FSEvents batch
+    /// (dirty set non-empty → "explained", banner off) and again when the
+    /// reconciler drains it (dirty set empty → "unexplained", banner on). On a
+    /// busy volume those two states alternate at FSEvents' cadence, which made
+    /// the banner blink on and off continuously after a large delete (statfs
+    /// hasn't handed the blocks back yet, so a real drift sits above the budget
+    /// the whole time). So the drift reason is *latched* instead of sampled:
+    ///
+    /// - it lights only after the drift has held over the budget for
+    ///   `driftSettleDelay` **and** nothing dirty is left to explain it — which
+    ///   also gives APFS time to return the freed blocks, killing the delete
+    ///   false-positive outright;
+    /// - once lit it stays lit through incoming churn, and only drops when the
+    ///   drift really collapses (hysteresis at a quarter of the budget) or a
+    ///   refresh re-baselines the accounting.
+    private func updateDriftLatch() {
+        let before = driftOverBudgetSince
+        (driftLatched, driftOverBudgetSince) = Self.driftLatch(
+            latched: driftLatched,
+            drift: driftBytes,
+            budget: diskChangeBudget,
+            dirtyPending: !dirtyNeeds.isEmpty,
+            overBudgetSince: before,
+            settleDelay: driftSettleDelay,
+            now: Date()
+        )
+        // The clock just started: nothing else will re-measure the drift on a
+        // quiet disk, so arm the one-shot that closes the window.
+        if before == nil, driftOverBudgetSince != nil { scheduleDriftSettleCheck() }
+    }
+
+    /// Pure latch policy (see `updateDriftLatch`) — arm after `settleDelay` over
+    /// the budget with nothing pending, disarm only under a quarter of it.
+    static func driftLatch(
+        latched: Bool,
+        drift: Int64,
+        budget: Int64,
+        dirtyPending: Bool,
+        overBudgetSince: Date?,
+        settleDelay: TimeInterval,
+        now: Date
+    ) -> (latched: Bool, overBudgetSince: Date?) {
+        guard abs(drift) >= budget else {
+            return (latched && abs(drift) >= budget / 4, nil)
+        }
+        guard !latched else { return (true, overBudgetSince) }
+        let since = overBudgetSince ?? now
+        let settled = !dirtyPending && now.timeIntervalSince(since) >= settleDelay
+        return (settled, since)
+    }
+
+    /// Re-measure the drift once the settle window has passed. Without it a
+    /// drift that appears between two FSEvents batches would wait for the next
+    /// batch to be re-evaluated — and on a quiet disk that batch never comes.
+    private func scheduleDriftSettleCheck() {
+        guard !driftSettleScheduled else { return }
+        driftSettleScheduled = true
+        let delay = driftSettleDelay
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(delay))
+            guard let self else { return }
+            self.driftSettleScheduled = false
+            guard self.isHostScan, self.phase == .finished, !self.isRefreshing else { return }
+            self.refreshDriftBytes()
+            self.updateBannerState()
         }
     }
 

--- a/Tests/SpaceMattersTests/IncrementalRefreshTests.swift
+++ b/Tests/SpaceMattersTests/IncrementalRefreshTests.swift
@@ -431,6 +431,47 @@ import Foundation
         #expect(c.changedBytes == 0)
     }
 
+    /// The drift banner must not blink: on a busy volume the dirty set empties
+    /// and refills at FSEvents' cadence, and sampling the drift raw made the
+    /// banner flap on and off after a big delete (real drift, statfs lagging).
+    /// The latch arms once, then rides through the churn.
+    @Test func driftLatchDoesNotFlapWithTheDirtySet() {
+        let budget: Int64 = 128 * 1024 * 1024
+        let over = budget * 4
+        let t0 = Date()
+        func latch(_ latched: Bool, _ drift: Int64, dirty: Bool, since: Date?, at: TimeInterval)
+            -> (latched: Bool, overBudgetSince: Date?) {
+            ScanController.driftLatch(latched: latched, drift: drift, budget: budget,
+                                      dirtyPending: dirty, overBudgetSince: since,
+                                      settleDelay: 5, now: t0.addingTimeInterval(at))
+        }
+
+        // Crossing the budget only starts the clock — no banner yet.
+        var s = latch(false, over, dirty: false, since: nil, at: 0)
+        #expect(!s.latched)
+        #expect(s.overBudgetSince == t0)
+        // Still inside the settle window: nothing.
+        s = latch(s.latched, over, dirty: false, since: s.overBudgetSince, at: 2)
+        #expect(!s.latched)
+        // Window elapsed but work is pending — it may yet explain the drift.
+        s = latch(s.latched, over, dirty: true, since: s.overBudgetSince, at: 6)
+        #expect(!s.latched)
+        #expect(s.overBudgetSince == t0)  // the clock keeps running under churn
+        // Settled and nothing pending: the banner earns its place.
+        s = latch(s.latched, over, dirty: false, since: s.overBudgetSince, at: 7)
+        #expect(s.latched)
+        // …and a new FSEvents batch (dirty again) must not take it away.
+        s = latch(s.latched, over, dirty: true, since: s.overBudgetSince, at: 8)
+        #expect(s.latched)
+        // A wobble just under the budget doesn't either (hysteresis).
+        s = latch(s.latched, budget - 1, dirty: false, since: s.overBudgetSince, at: 9)
+        #expect(s.latched)
+        // A real collapse does.
+        s = latch(s.latched, budget / 8, dirty: false, since: s.overBudgetSince, at: 10)
+        #expect(!s.latched)
+        #expect(s.overBudgetSince == nil)
+    }
+
     /// A *leaf* directory whose extension table a re-stat snapshotted is fully
     /// known — when it vanishes, its File-types contribution is subtracted
     /// exactly and no drift is ever marked (the watched-download-vanishing QA


### PR DESCRIPTION
## The bug

Delete a large file and the banner *\"The disk grew by ~46,2 GiB outside the mapped folders.\"* appears and disappears about once a second, indefinitely.

## Cause

The drift reason was **sampled raw** on every state change:

```swift
let unexplained = dirtyNeeds.isEmpty && abs(driftBytes) >= diskChangeBudget
```

Its two terms alternate at FSEvents' cadence on a busy volume:

- `handleDiskChanges` — a batch lands, `dirtyNeeds` is non-empty → banner **off**;
- end of `reconcileNow` — the reconciler drained the set → banner **on**.

After a big delete the drift stays genuinely over budget throughout: the tree absorbs `-46 GiB` the instant the delta applies, while `statfs` returns the blocks lazily (APFS purgeable, local snapshots, Trash). So the condition's second term never settles the question, and the first term toggles the banner once per FSEvents batch.

## Fix

The drift reason becomes a **latch** with a settle window and hysteresis:

- it arms only after `driftSettleDelay` (5 s) over the budget **and** with nothing dirty left to explain it — which also gives APFS time to hand back the freed blocks, so the delete false-positive usually resolves on its own;
- once armed it rides through incoming churn, and drops only when the drift really collapses (hysteresis at a quarter of the budget) or a refresh re-baselines the accounting;
- a one-shot `scheduleDriftSettleCheck` re-measures the drift when the window closes — on a quiet disk no further event would reopen the question.

The policy is extracted as a pure static `ScanController.driftLatch(...)`, same shape as `planReconciliation`.

The **root-gone** and **consent** reasons are untouched: they still light the banner immediately, unlatched.

## Remaining, intended behaviour

If the space genuinely isn't returned (file sent to the Trash, a Time Machine snapshot pinning it), the banner appears **once** after 5 s and stays — an honest state, and Refresh settles it.

## Tests

`driftLatchDoesNotFlapWithTheDirtySet` replays the exact sequence of the bug: budget crossed → inside the window → window elapsed but work pending → settled (arms) → new dirty batch (stays) → wobble just under budget (stays) → real collapse (drops).

`swift test`: 117 tests, all passing.