### PR TITLE
feat(cleanup): add the Notion cache as a Low-Hanging Fruits target

### DIFF
--- a/Sources/SpaceMatters/Scanner/CleanupEngine.swift
+++ b/Sources/SpaceMatters/Scanner/CleanupEngine.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(AppKit)
+import AppKit
+#endif
 
 /// A known-safe cleanup target for the Low-Hanging Fruits mode: a location whose
 /// contents are regenerable by design (package/build caches) or explicitly
@@ -35,6 +38,23 @@ enum CleanupEngine {
                 id: "trash", name: "Trash", category: "System", icon: "trash.fill",
                 note: "Files you already deleted. Emptying is permanent.",
                 paths: [home + "/.Trash"]),
+            // Notion's service worker never evicts: it keeps one full asset
+            // bucket per app release it has ever run (`notion-swv2-<version>`
+            // in CacheStorage/*/index.txt), so the directory grows by a few
+            // hundred MB per update and never shrinks. Deliberately narrow —
+            // the two HTTP-level caches of the `notion` partition only. Its
+            // siblings hold state the app cannot refetch: IndexedDB (unsynced
+            // edits), File System (offline attachments), Local Storage,
+            // Cookies (the session). See `notionIsRunning` for the live-app
+            // guard — the reason this target is app-specific rather than a
+            // generic "Electron caches" sweep.
+            Cleanable(
+                id: "notion", name: "Notion cache", category: "Apps", icon: "note.text",
+                note: "Web assets, re-downloaded at next launch — quit Notion first.",
+                paths: [
+                    home + "/Library/Application Support/Notion/Partitions/notion/Service Worker/CacheStorage",
+                    home + "/Library/Application Support/Notion/Partitions/notion/Cache",
+                ]),
             Cleanable(
                 id: "derived-data", name: "Xcode DerivedData", category: "Apple development", icon: "hammer.fill",
                 note: "Per-project build artifacts. Xcode rebuilds them on demand.",
@@ -257,6 +277,31 @@ enum CleanupEngine {
             }
         }
         return false
+    }
+
+    /// Notion's bundle identifier, and the helpers it spawns under it.
+    static let notionBundleID = "notion.id"
+
+    /// True while Notion is running — the target must not be offered then.
+    ///
+    /// This is the difference between an app cache and a package cache, and why
+    /// the catalog names apps one by one instead of sweeping every Electron
+    /// directory: a package manager is invoked and exits, a desktop app holds
+    /// its cache open for hours. Unlinking underneath it is not a crash on
+    /// macOS (the inode outlives the last close), but the service worker keeps
+    /// writing into files nothing can reach any more — the space is not
+    /// actually freed until quit, and the cache index can be left describing
+    /// entries that no longer exist. Quitting first makes both go away.
+    ///
+    /// Fails closed: when the running-app list cannot be consulted at all, the
+    /// target is treated as busy rather than assumed idle.
+    static func notionIsRunning() -> Bool {
+        #if canImport(AppKit)
+        return !NSRunningApplication.runningApplications(
+            withBundleIdentifier: notionBundleID).isEmpty
+        #else
+        return true
+        #endif
     }
 
     /// True only for a directory that is not itself a symlink (`lstat`, so the

--- a/Sources/SpaceMatters/ViewModel/CleanupController.swift
+++ b/Sources/SpaceMatters/ViewModel/CleanupController.swift
@@ -72,9 +72,14 @@ final class CleanupController {
                                     timeout: native.timeout, environment: native.environment)
          },
          blockedReason: @escaping @Sendable (String, String) -> String? = { id, home in
-            id == "uv" && CleanupEngine.uvSymlinkMode(home: home)
-                ? "uv link-mode is \"symlink\" — cleaning would break your virtualenvs"
-                : nil
+            switch id {
+            case "uv" where CleanupEngine.uvSymlinkMode(home: home):
+                return "uv link-mode is \"symlink\" — cleaning would break your virtualenvs"
+            case "notion" where CleanupEngine.notionIsRunning():
+                return "Notion is running — quit it first, or it keeps writing to the cache"
+            default:
+                return nil
+            }
          },
          journal: @escaping (CleanupJournal.Entry) -> Void = { CleanupJournal.append($0) }) {
         self.catalog = catalog

--- a/Tests/SpaceMattersTests/CleanupTests.swift
+++ b/Tests/SpaceMattersTests/CleanupTests.swift
@@ -60,9 +60,9 @@ import Foundation
     /// (IndexedDB), offline attachments (File System), the session (Cookies) —
     /// so widening the paths by one directory turns a regenerable cache into
     /// data loss. Pinned by name: a future edit has to break this to ship.
-    @Test func notionTargetTouchesOnlyCaches() {
+    @Test func notionTargetTouchesOnlyCaches() throws {
         let home = NSHomeDirectory()
-        let notion = try! #require(CleanupEngine.catalog().first { $0.id == "notion" })
+        let notion = try #require(CleanupEngine.catalog().first { $0.id == "notion" })
         let partition = home + "/Library/Application Support/Notion/Partitions/notion/"
 
         #expect(notion.paths == [partition + "Service Worker/CacheStorage",

--- a/Tests/SpaceMattersTests/CleanupTests.swift
+++ b/Tests/SpaceMattersTests/CleanupTests.swift
@@ -55,6 +55,51 @@ import Foundation
         }
     }
 
+    /// The Notion target names caches and nothing else. Its siblings inside the
+    /// same partition hold state the app cannot refetch — unsynced edits
+    /// (IndexedDB), offline attachments (File System), the session (Cookies) —
+    /// so widening the paths by one directory turns a regenerable cache into
+    /// data loss. Pinned by name: a future edit has to break this to ship.
+    @Test func notionTargetTouchesOnlyCaches() {
+        let home = NSHomeDirectory()
+        let notion = try! #require(CleanupEngine.catalog().first { $0.id == "notion" })
+        let partition = home + "/Library/Application Support/Notion/Partitions/notion/"
+
+        #expect(notion.paths == [partition + "Service Worker/CacheStorage",
+                                 partition + "Cache"])
+        for forbidden in ["IndexedDB", "Local Storage", "Session Storage", "File System",
+                          "Cookies", "Databases", "blob_storage", "Preferences",
+                          "Service Worker/Database"] {
+            #expect(!notion.paths.contains { $0.hasSuffix("/" + forbidden) },
+                    "\(forbidden) is not regenerable — it must never be a cleanup path")
+        }
+    }
+
+    /// A running Notion blocks its own row: the app holds the cache open, so
+    /// deleting underneath it frees nothing until quit and can leave the cache
+    /// index describing entries that are gone.
+    @Test func notionRowIsBlockedWhileTheAppRuns() async throws {
+        let (root, cache) = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let notion = Cleanable(id: "notion", name: "Notion cache", category: "Apps",
+                               icon: "note.text", note: "fixture", paths: [cache.path])
+        let c = CleanupController(
+            catalog: [notion], allowedRoot: root.path,
+            blockedReason: { id, _ in
+                id == "notion" ? "Notion is running — quit it first" : nil
+            },
+            journal: { _ in })
+        c.load()
+        await Self.waitForReady(c)
+
+        #expect(c.rows.first?.size == .blocked("Notion is running — quit it first"))
+        c.toggleAll() // select-all must not sweep a blocked app row up
+        #expect(c.selectedRows.isEmpty)
+
+        await c.cleanSelected()
+        #expect(FileManager.default.fileExists(atPath: cache.appendingPathComponent("a.bin").path))
+    }
+
     // MARK: Engine
 
     @Test func sizingMeasuresFixture() throws {


### PR DESCRIPTION
## The find

Notion's service worker never evicts. It keeps **one full asset bucket per app release it has ever run** — visible in `CacheStorage/*/index.txt` as `notion-swv2-<version>`:

```
notion-swv2-23.13.20260527.0705
notion-swv2-images
notion-swv2-version
```

So the directory grows by a few hundred MB per update and never shrinks. On the machine this was written on, 26 stale buckets of ~4 400 entries each had piled up:

| Path | Size |
|---|---|
| `Partitions/notion/Service Worker/CacheStorage` | 12 GiB |
| `Partitions/notion/Cache` | 1.3 GiB |
| **Total** | **13.26 GiB** |

For scale, that is roughly **four times every dev cache already in the catalog combined** (SwiftPM + npm + NuGet + pip + go + Homebrew ≈ 3.1 GiB there).

## Why app-specific and not a generic Electron sweep

A generic "walk `~/Library/Application Support/*/` and delete anything named `Cache`" was considered and rejected. Two reasons, and the second is the one that matters:

1. It would violate the catalog's stated contract — *"the catalog is hand-picked, nothing is discovered dynamically"* ([`CleanupEngine`](../blob/main/Sources/SpaceMatters/Scanner/CleanupEngine.swift) header).
2. **A package cache and an app cache are not the same object.** A package manager is invoked and exits. A desktop app holds its cache open for hours. That difference needs a per-app guard, which needs a per-app bundle identifier — there is nothing generic to write.

## What it touches, and what it must never touch

Two paths, both HTTP-level caches of the `notion` partition. Their siblings live in the same directory and hold state the app **cannot refetch**:

| Sibling | | Left alone |
|---|---|---|
| `IndexedDB` | unsynced edits | ✅ |
| `File System` | offline attachments | ✅ |
| `Local Storage` | UI preferences | ✅ |
| `Cookies` | the session | ✅ |

`notionTargetTouchesOnlyCaches` pins the path list **by name** and asserts none of the nine non-regenerable siblings can appear in it. Widening the target by one directory turns a regenerable cache into data loss, so it has to break the build to ship.

`Code Cache` (23 MiB) and `GPUCache` (548 KiB) were left out on purpose: zero additional risk, negligible gain, two more paths to defend.

## The live-app guard

The target is blocked while Notion runs, through the same `blockedReason` mechanism as uv's symlink mode. Unlinking underneath a running Chromium is not a crash on macOS — the inode outlives the last close — but the service worker keeps writing into files nothing can reach any more: **the space is not actually freed until quit**, and the cache index can be left describing entries that no longer exist. Quitting first makes both go away.

Fails closed: when the running-app list cannot be consulted at all, the target is treated as busy rather than assumed idle.

## Verified end to end

Not a dry run — this was executed against the real 13 GiB cache:

```
2026-08-16T14:50:11Z  notion  engine=file
  before=13.26 GiB  after=0.00 MiB  removed=4  failed=0  refused=0
```

- 13.26 GiB freed, no failures, no fence refusals
- **Session preserved** — Notion relaunched still logged in, confirming `Cookies` was untouched
- Notion rebuilt ~22 MiB of current-version cache on next launch, as designed
- Full suite green (119 tests)

## Residual risk, stated in the UI

Notion must refetch its assets at next launch, so cleaning while offline leaves it unable to start properly until back online. That is what the row's note says: *"Web assets, re-downloaded at next launch — quit Notion first."*

## Known follow-up, not in this PR

The cache is ~130 000 tiny files, so removal takes on the order of a minute and the UI shows no progress during it — `state == .cleaning` and nothing else. Dev caches are small enough that this never showed; Notion is the first target that surfaces it. Worth a progress counter in a separate change.
