### PR TITLE
feat(cleanup): Go module cache target, native-required class, and scanner-backed sizing

### DIFF
--- a/Sources/SpaceMatters/Scanner/CleanupEngine.swift
+++ b/Sources/SpaceMatters/Scanner/CleanupEngine.swift
@@ -111,6 +111,16 @@ enum CleanupEngine {
                 id: "go-build", name: "Go build cache", category: "Rust & Go", icon: "wrench.and.screwdriver",
                 note: "Compiled build cache, rebuilt on demand.",
                 paths: [home + "/Library/Caches/go-build"]),
+            // GOPATH's default location only. A GUI app inherits no shell
+            // environment, so `$GOPATH` would read empty here far more often
+            // than it would read true; a relocated cache is simply not detected
+            // (and if it lives outside home, the fence would refuse it anyway).
+            // The clean itself doesn't rely on this path — `go clean -modcache`
+            // resolves its own location, env overrides included.
+            Cleanable(
+                id: "go-mod", name: "Go module cache", category: "Rust & Go", icon: "shippingbox.circle.fill",
+                note: "Module sources and zips, re-downloaded on next build (needs network).",
+                paths: [home + "/go/pkg/mod"]),
             Cleanable(
                 id: "homebrew", name: "Homebrew downloads", category: "Homebrew", icon: "mug.fill",
                 note: "Bottle, cask and API downloads, re-fetched on demand.",

--- a/Sources/SpaceMatters/Scanner/CleanupEngine.swift
+++ b/Sources/SpaceMatters/Scanner/CleanupEngine.swift
@@ -151,50 +151,50 @@ enum CleanupEngine {
         case denied
     }
 
-    /// Physical bytes under the item's paths, via the same `getattrlistbulk`
-    /// walk as the scanner (symlinks counted as their own size, never followed;
-    /// mount points not crossed). Runs off the main thread.
+    /// Physical bytes under the item's paths.
+    ///
+    /// The walk itself is `DirectoryScanner`, seeded with the item's paths
+    /// instead of a volume — the engine is built for exactly this ("multiple
+    /// seeds let a single scan span several volumes, all aggregating into a
+    /// shared virtual root"), so a cache is measured by the same worker pool
+    /// that scans a whole disk rather than by a second, single-threaded walk.
+    /// Sizes reach `total` up the parent chain, so the seed nodes only need a
+    /// parent, never to be attached as children.
+    ///
+    /// The roots are still opened here first, with `O_NOFOLLOW`, for two
+    /// reasons the scanner cannot cover: it opens without `O_NOFOLLOW`, so a
+    /// symlinked root would be measured *through* its link — precisely what
+    /// `detect` and `clean` refuse — and it counts unreadable directories
+    /// without distinguishing the one case the UI acts on, a root that exists
+    /// but cannot be opened (the Trash without Full Disk Access).
+    ///
+    /// Counting matches `clean`: `exact: false`, so every hard link is counted,
+    /// like the file removal that follows. Runs off the main thread; the pool
+    /// is not shared, so callers size one item at a time.
     static func size(of item: Cleanable) -> Measure {
-        var total: Int64 = 0
-        var openedAny = false
+        let total = FSNode(name: "cleanup", parent: nil)
+        var seeds: [DirectoryScanner.Seed] = []
         var deniedRoot = false
-        let buffer = UnsafeMutableRawPointer.allocate(byteCount: bufferSize, alignment: 16)
-        defer { buffer.deallocate() }
 
         for root in item.paths {
-            var stack = [root]
-            while let dir = stack.popLast() {
-                // O_NOFOLLOW: a symlinked root must not be measured through its
-                // target (detect refuses it; clean would too), and a directory
-                // swapped for a link between enumeration and open is not chased.
-                let fd = open(dir, O_RDONLY | O_DIRECTORY | O_NOFOLLOW)
-                guard fd >= 0 else {
-                    // ENOENT and EACCES are different stories: a root that no
-                    // longer exists is *empty* (native cleaners like dotnet
-                    // remove their directories outright), only a root we're not
-                    // allowed to open reads as "needs access".
-                    if dir == root && (errno == EACCES || errno == EPERM) { deniedRoot = true }
-                    continue
-                }
-                if dir == root { openedAny = true }
-                let prefix = dir + "/"
-                _ = enumerateDirectory(fd: fd, buffer: buffer, bufferSize: bufferSize) { entry in
-                    if entry.isDirectory {
-                        if entry.isMountPoint { return }
-                        let name = String(
-                            decoding: UnsafeRawBufferPointer(start: entry.name, count: entry.nameLength),
-                            as: UTF8.self
-                        )
-                        stack.append(prefix + name)
-                    } else {
-                        total += entry.physicalSize
-                    }
-                }
-                close(fd)
+            let fd = open(root, O_RDONLY | O_DIRECTORY | O_NOFOLLOW)
+            guard fd >= 0 else {
+                // ENOENT and EACCES are different stories: a root that no
+                // longer exists is *empty* (native cleaners like dotnet and go
+                // remove their directories outright), only a root we're not
+                // allowed to open reads as "needs access".
+                if errno == EACCES || errno == EPERM { deniedRoot = true }
+                continue
             }
+            close(fd)
+            seeds.append(DirectoryScanner.Seed(path: root, node: FSNode(name: root, parent: total)))
         }
-        if openedAny { return .sized(total) }
-        return deniedRoot ? .denied : .sized(0)
+
+        guard !seeds.isEmpty else { return deniedRoot ? .denied : .sized(0) }
+        let scanner = DirectoryScanner(root: total, seeds: seeds)
+        scanner.start()
+        scanner.waitUntilFinished()
+        return .sized(total.sizeOnDisk)
     }
 
     // MARK: Cleaning
@@ -337,6 +337,4 @@ enum CleanupEngine {
     private static func resolvedPath(_ path: String) -> String {
         URL(fileURLWithPath: path).standardizedFileURL.resolvingSymlinksInPath().path
     }
-
-    private static let bufferSize = 256 * 1024
 }

--- a/Sources/SpaceMatters/Scanner/NativeCleaner.swift
+++ b/Sources/SpaceMatters/Scanner/NativeCleaner.swift
@@ -19,6 +19,32 @@ struct NativeCleaner: Sendable, Equatable {
     /// Display name shown in the row and the journal ("brew cleanup").
     let label: String
 
+    /// Targets whose vendor command is not a preference but the *only* viable
+    /// path, mapped to the reason shown when its binary is missing.
+    ///
+    /// Go extracts every module into a tree it then marks read-only (`0555`,
+    /// deepest first). Unlinking an entry needs write permission on its parent
+    /// *directory*, not on the entry, so file removal returns EACCES on every
+    /// module — `rm -rf` fails the same way, which is why `go clean -modcache`
+    /// exists. Offering the target without the toolchain would walk 15 GB and
+    /// free nothing, reporting a wall of failures.
+    static let nativeRequired: [String: String] = [
+        "go-mod": "needs the Go toolchain — Go marks module files read-only, "
+            + "only `go clean -modcache` can empty the cache",
+    ]
+
+    /// The reason a *native-required* target cannot run here, or nil when it
+    /// can (or when the target has no such requirement). Drives `blockedReason`
+    /// in `CleanupController`, so the row is shown and explained rather than
+    /// silently offering a clean that would fail on every file.
+    static func missingRequirement(
+        for targetID: String, home: String = NSHomeDirectory(),
+        isExecutable: (String) -> Bool = { FileManager.default.isExecutableFile(atPath: $0) }
+    ) -> String? {
+        guard let reason = nativeRequired[targetID] else { return nil }
+        return available(for: targetID, home: home, isExecutable: isExecutable) == nil ? reason : nil
+    }
+
     /// The native cleaner for a catalog target, when its binary exists.
     /// Candidates are fixed absolute paths: a GUI app inherits no shell PATH,
     /// and probing the known install prefixes beats guessing an environment.
@@ -70,6 +96,14 @@ struct NativeCleaner: Sendable, Equatable {
                              "/usr/local/bin/go"],
                 arguments: ["clean", "-cache"],
                 environment: [:], timeout: 600, label: "go clean -cache"),
+            // Not an optimization — see `nativeRequired`. Removes the module
+            // cache root outright (like `dotnet nuget locals`), which sizing
+            // and detection already treat as "empty", not as an error.
+            "go-mod": Spec(
+                candidates: ["/opt/homebrew/bin/go", "/usr/local/go/bin/go",
+                             "/usr/local/bin/go"],
+                arguments: ["clean", "-modcache"],
+                environment: [:], timeout: 600, label: "go clean -modcache"),
         ]
     }
 }

--- a/Sources/SpaceMatters/ViewModel/CleanupController.swift
+++ b/Sources/SpaceMatters/ViewModel/CleanupController.swift
@@ -72,6 +72,13 @@ final class CleanupController {
                                     timeout: native.timeout, environment: native.environment)
          },
          blockedReason: @escaping @Sendable (String, String) -> String? = { id, home in
+            // A target whose vendor command is the only viable path is blocked
+            // when that command is missing, rather than offered a file removal
+            // that would fail on every entry (go-mod). Checked first: it is a
+            // property of the target, not of this machine's state.
+            if let missing = NativeCleaner.missingRequirement(for: id, home: home) {
+                return missing
+            }
             switch id {
             case "uv" where CleanupEngine.uvSymlinkMode(home: home):
                 return "uv link-mode is \"symlink\" — cleaning would break your virtualenvs"

--- a/Sources/SpaceMatters/ViewModel/CleanupController.swift
+++ b/Sources/SpaceMatters/ViewModel/CleanupController.swift
@@ -2,8 +2,9 @@ import Foundation
 import Observation
 
 /// Drives the Low-Hanging Fruits mode: detects the known-safe cleanup targets,
-/// sizes them concurrently (rows fill in live, like a scan), and empties the
-/// selected ones. Nothing is pre-selected — cleaning is always an explicit
+/// sizes them one at a time (each walk drives the scanner's whole worker pool,
+/// so rows still fill in live — in order rather than all at once), and empties
+/// the selected ones. Nothing is pre-selected — cleaning is always an explicit
 /// choice, and it is refused while sizing or another clean is in flight.
 @MainActor
 @Observable
@@ -125,8 +126,13 @@ final class CleanupController {
                 selected: previouslySelected.contains($0.id) && blocked[$0.id] == nil)
         }
         state = rows.contains { $0.size == .pending } ? .sizing : .ready
-        for item in detected where blocked[item.id] == nil {
-            Task {
+        // One target at a time. Each sizing walk now drives the full scanner
+        // worker pool, so running the targets concurrently would multiply
+        // threads rather than work — and the slowest target used to set the
+        // whole mode's load time anyway. Rows still fill in live, in order.
+        let pending = detected.filter { blocked[$0.id] == nil }
+        Task {
+            for item in pending {
                 let measure = await Task.detached(priority: .userInitiated) {
                     CleanupEngine.size(of: item)
                 }.value

--- a/Tests/SpaceMattersTests/CleanupTests.swift
+++ b/Tests/SpaceMattersTests/CleanupTests.swift
@@ -100,6 +100,47 @@ import Foundation
         #expect(FileManager.default.fileExists(atPath: cache.appendingPathComponent("a.bin").path))
     }
 
+    /// The reason `go-mod` is native-required, pinned as an executable fact
+    /// rather than a comment: Go marks each extracted module tree read-only
+    /// (0555, deepest first), and unlinking an entry needs write permission on
+    /// its parent *directory*. So the file engine reports failures and frees
+    /// nothing — exactly what `rm -rf $GOPATH/pkg/mod` does. If this ever
+    /// starts passing, the toolchain requirement can be reconsidered.
+    @Test func fileRemovalCannotEmptyAReadOnlyGoModuleTree() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent("sm-gomod-\(UUID().uuidString)")
+        let cache = root.appendingPathComponent("pkg/mod")
+        let module = cache.appendingPathComponent("example.com/lib@v1.0.0")
+        try fm.createDirectory(at: module.appendingPathComponent("internal"), withIntermediateDirectories: true)
+        try Data(count: 4096).write(to: module.appendingPathComponent("internal/lib.go"))
+        // Deepest first, as `go mod download` does.
+        for dir in [module.appendingPathComponent("internal"), module,
+                    cache.appendingPathComponent("example.com")] {
+            try fm.setAttributes([.posixPermissions: 0o555], ofItemAtPath: dir.path)
+        }
+        defer {
+            for dir in [cache.appendingPathComponent("example.com"), module,
+                        module.appendingPathComponent("internal")] {
+                try? fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: dir.path)
+            }
+            try? fm.removeItem(at: root)
+        }
+
+        let result = CleanupEngine.clean(Self.cleanable([cache.path]), allowedRoot: root.path)
+
+        #expect(result.failed == 1 && result.removed == 0)
+        #expect(fm.fileExists(atPath: module.appendingPathComponent("internal/lib.go").path))
+    }
+
+    /// The module cache target points at GOPATH's documented default and is
+    /// the one entry that blocks without its toolchain.
+    @Test func goModCacheTargetsTheDefaultGopath() throws {
+        let goMod = try #require(CleanupEngine.catalog(home: "/Users/x").first { $0.id == "go-mod" })
+        #expect(goMod.paths == ["/Users/x/go/pkg/mod"])
+        #expect(NativeCleaner.missingRequirement(
+            for: goMod.id, home: "/Users/x", isExecutable: { _ in false }) != nil)
+    }
+
     // MARK: Engine
 
     @Test func sizingMeasuresFixture() throws {

--- a/Tests/SpaceMattersTests/CleanupTests.swift
+++ b/Tests/SpaceMattersTests/CleanupTests.swift
@@ -154,6 +154,31 @@ import Foundation
         #expect(bytes >= 150_000) // physical ≥ logical of the two files
     }
 
+    /// A multi-path target (NuGet, Notion) becomes several scanner seeds whose
+    /// sizes reach the total up the parent chain, not through the child list —
+    /// so the total must be the sum of every path, and a missing one must not
+    /// void the others.
+    @Test func sizingAggregatesEveryPathOfATarget() throws {
+        let (root, cache) = try Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let second = root.appendingPathComponent("cache2")
+        try FileManager.default.createDirectory(at: second, withIntermediateDirectories: true)
+        try Data(count: 200_000).write(to: second.appendingPathComponent("c.bin"))
+
+        let both = CleanupEngine.size(of: Self.cleanable(
+            [cache.path, second.path, root.appendingPathComponent("absent").path]))
+        let first = CleanupEngine.size(of: Self.cleanable([cache.path]))
+        let other = CleanupEngine.size(of: Self.cleanable([second.path]))
+
+        guard case .sized(let bothBytes) = both, case .sized(let firstBytes) = first,
+              case .sized(let otherBytes) = other else {
+            Issue.record("expected .sized for all three, got \(both) / \(first) / \(other)")
+            return
+        }
+        #expect(bothBytes == firstBytes + otherBytes)
+        #expect(otherBytes >= 200_000)
+    }
+
     @Test func cleanRemovesContentsButKeepsRoot() throws {
         let (root, cache) = try Self.makeFixture()
         defer { try? FileManager.default.removeItem(at: root) }

--- a/Tests/SpaceMattersTests/NativeCleanerTests.swift
+++ b/Tests/SpaceMattersTests/NativeCleanerTests.swift
@@ -25,6 +25,29 @@ struct NativeCleanerTests {
         #expect(NativeCleaner.available(for: "homebrew", isExecutable: { _ in false }) == nil)
     }
 
+    /// The module cache is the one target whose vendor command is mandatory,
+    /// not preferred: without the toolchain it must report a reason, not fall
+    /// back to a file removal that cannot work (see `fileRemovalCannotEmptyA
+    /// ReadOnlyGoModuleTree` in CleanupTests for the why).
+    @Test func goModCacheRequiresTheToolchain() {
+        #expect(NativeCleaner.missingRequirement(for: "go-mod", isExecutable: { _ in false }) != nil)
+        #expect(NativeCleaner.missingRequirement(for: "go-mod", isExecutable: { _ in true }) == nil)
+
+        let native = NativeCleaner.available(for: "go-mod", isExecutable: { $0 == "/opt/homebrew/bin/go" })
+        #expect(native?.arguments == ["clean", "-modcache"])
+        #expect(native?.label == "go clean -modcache")
+    }
+
+    /// Every other target stays a file-engine target: a missing binary is a
+    /// fallback, never a block. Pinning this keeps the requirement narrow.
+    @Test func noOtherTargetIsNativeRequired() {
+        #expect(NativeCleaner.nativeRequired.keys.sorted() == ["go-mod"])
+        for id in ["go-build", "homebrew", "pnpm", "nuget", "npm", "trash"] {
+            #expect(NativeCleaner.missingRequirement(for: id, isExecutable: { _ in false }) == nil,
+                    "\(id) must fall back to file removal, not block")
+        }
+    }
+
     @Test func brewRunsWithHygieneEnvironment() {
         let native = NativeCleaner.available(for: "homebrew", isExecutable: { _ in true })
         #expect(native?.environment["HOMEBREW_NO_AUTO_UPDATE"] == "1")


### PR DESCRIPTION
Two commits: the target, and the performance problem it exposed.

## 1. The Go module cache

`~/go/pkg/mod` is **15.1 GiB** on the machine this was written on — the largest reclaimable location in the mode after the Notion cache — and Low-Hanging Fruits showed nothing for it. Only `go-build` was in the catalog, worth 1.73 MiB here.

### It cannot be a plain file target

Go extracts every module into a tree it then marks read-only (`0555`, deepest first). Unlinking an entry needs write permission on its **parent directory**, not on the entry, so file removal returns `EACCES` on every module. Verified rather than assumed:

```
rm -rf mod/pkg@v1.0.0
  rm: mod/pkg@v1.0.0/sub/f.go: Permission denied
  rm: mod/pkg@v1.0.0: Directory not empty

FileManager.removeItem: FAILED — "pkg@v1.0.0" couldn't be removed
  because you don't have permission to access it
```

This is why `go clean -modcache` exists. Offering the target without the toolchain would walk 15 GB and free nothing, reporting a wall of failures.

### A third target class

The catalog had "file engine" and "native preferred" (brew, pnpm, dotnet — a better way when present, plain removal otherwise). This adds **native required**: `NativeCleaner.nativeRequired` maps such a target to the reason shown when its binary is missing, and `blockedReason` turns it into the existing blocked row — shown and explained rather than silently offering a clean that cannot work.

Two tests keep this honest:

- `fileRemovalCannotEmptyAReadOnlyGoModuleTree` pins the underlying fact as executable, not as a comment. If it ever starts passing, the requirement can be reconsidered.
- `noOtherTargetIsNativeRequired` keeps the class narrow — every other target must still fall back to file removal.

The entry points at GOPATH's documented default only: a GUI app inherits no shell environment, so `$GOPATH` would read empty far more often than true. The clean doesn't depend on it — `go clean -modcache` resolves its own location, and removes the root outright like `dotnet nuget locals` already does (sizing and detection already treat that as "empty", not as an error).

## 2. The sizing was single-threaded

Adding the target made the mode look hung — the summary sat on "still measuring…" for the better part of a minute. The disk was not the problem:

| | |
|---|---|
| `~/go/pkg/mod` | 637 k files, **118 k directories** |
| `find -type d` | 3.0 s at **467 % CPU** |
| Full disk scan, same machine | 4.1 M files in 33.4 s |

`CleanupEngine.size` was the only walker in the codebase without the worker pool: a single `stack`/`while` loop on one thread. It already used `getattrlistbulk`, so there was no per-file `stat` to remove — it simply visited 118 k directories one at a time.

### Reusing the engine rather than writing a second one

Nothing had to be built. `DirectoryScanner` already accepts arbitrary seeds — *"multiple seeds let a single scan span several volumes, all aggregating into a shared (virtual) root"* — which is exactly the shape of a multi-path cleanup target. Seeding it with the item's paths and reading `sizeOnDisk` off the shared root reuses the pool as-is. There is no tree to pay for either: nodes are per-directory, and the whole thing is dropped once the total is read.

**Measured on the real 15.1 GiB cache: 23.57 s → 4.06 s (5.8x), byte-identical totals** (`16184893440` both ways).

### What the scanner cannot do, kept explicit

- It opens directories **without `O_NOFOLLOW`**. The roots are still opened locally first, so a symlinked root is never measured *through* its link — what `detect` and `clean` refuse, and what `sizeNeverMeasuresThroughSymlinkedRoot` pins.
- It counts unreadable directories without isolating the one case the UI acts on: a root that exists but cannot be opened (the Trash without Full Disk Access). That check stays explicit.
- Counting matches `clean`: `exact: false`, every hard link counted, like the removal that follows.

Targets are now sized **one at a time**. Each walk drives the full pool, so keeping them concurrent would multiply threads rather than work (9 targets × 12 workers), and the slowest target set the mode's load time anyway. Rows still fill in live, in order.

`sizingAggregatesEveryPathOfATarget` covers the new aggregation path: sizes reach the total up the parent chain, not through the child list, so a multi-path target (NuGet, Notion) must still sum exactly and a missing path must not void the others.

## Verified

- 122 tests green, SwiftLint strict clean
- In the app: row present, **15.1 GiB** sized, selectable, `via go clean -modcache` badge, mode total 17.6 GiB
- The clean itself was **not** executed on this machine — the sizing and blocking paths are what was exercised end to end

## Not in this PR

Cleaning a very large target still shows no progress (`state == .cleaning` and nothing else). That is the deletion side of the same story and belongs in its own change.
