### PR TITLE
ci(renovate): drop unreachable automerge, freeze the macOS runner, track the inline zizmor pin

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,12 +6,34 @@
   "labels": ["dependencies"],
   "vulnerabilityAlerts": { "enabled": true, "schedule": ["at any time"], "labels": ["security"] },
   "pre-commit": { "enabled": true },
+  "customManagers": [
+    {
+      "description": "CI pins zizmor inline (pipx run zizmor==X); the pre-commit manager cannot see it.",
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/ci\\.yml$/"],
+      "matchStrings": ["zizmor==(?<currentValue>\\d+\\.\\d+\\.\\d+)"],
+      "depNameTemplate": "zizmorcore/zizmor",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    }
+  ],
   "packageRules": [
     {
+      "description": "No automerge: the 'main protect' ruleset requires an approving review the bot cannot bypass.",
       "matchManagers": ["github-actions"],
       "groupName": "github-actions",
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": true
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"]
+    },
+    {
+      "description": "The runner image is the SDK we build against: macOS 26 would opt the app into the new design language and leave no macOS 15 machine in CI. Deliberate bump only — see platforms in Package.swift for the actual deployment target.",
+      "matchDatasources": ["github-runners"],
+      "matchPackageNames": ["macos"],
+      "enabled": false
+    },
+    {
+      "description": "Keep the inline CI pin and the pre-commit hook in one PR so they never drift.",
+      "matchPackageNames": ["zizmorcore/zizmor", "zizmorcore/zizmor-pre-commit"],
+      "groupName": "zizmor"
     },
     { "matchDatasources": ["docker"], "groupName": "docker base images" }
   ]


### PR DESCRIPTION
Audit of the Renovate setup. The reason no dependency PR had landed since 6 July is **not** in this file: the repo is in **Silent mode** on the Mend portal, so Renovate runs (v44.29.5, jobs daily), detects everything correctly, but writes nothing back — no branch, no PR, and no refresh of the stale Dependency Dashboard issue (#2). That toggle has to be flipped in the portal.

The audit did surface three real problems here.

### `automerge` was unreachable

The `github-actions` group asked for automerge, but the `main protect` ruleset requires one approving review with a bypass limited to `OrganizationAdmin`. Renovate is not an admin, and `allow_auto_merge` is off on the repo, so both merge paths were closed: the PRs would have sat open on a green CI, which reads as "waiting on someone" when nothing could ever happen.

The alternative is adding the app to the ruleset bypass list. That grants a blanket review waiver on *every* Renovate PR, digest bumps of third-party actions included — which sits badly next to the pinned digests, zizmor and betterleaks this repo already runs. Dropped the automerge instead; the bypass remains available if the trade is ever wanted.

### The macOS runner is now a deliberate bump

`runs-on: macos-15` is the build machine, not the minimum supported macOS — that one lives in `platforms: [.macOS(.v15)]` in `Package.swift` and Renovate never touches it. But the runner does decide the SDK: linking against the macOS 26 SDK opts the app into the new design language, and it would leave no macOS 15 machine in CI. Product decision, not routine maintenance, so the update is disabled with the reasoning recorded in `description`. GitHub will retire the `macos-15` image eventually; this is a "decide later", not a "never".

### The inline zizmor pin is now tracked

`.github/workflows/ci.yml` pinned `zizmor==1.25.2` with a comment stating the version matches the pre-commit hook — the hook was on `v1.26.1`. No manager could see the inline pin, so the pending hook bump to 1.29.0 would have widened the gap silently. A regex custom manager now tracks it, grouped with the hook so both move in one PR.

### Verification

`renovate-config-validator` passes. A local extraction (`renovate --platform=local`) confirms the pin resolves as `zizmorcore/zizmor` `1.25.2` (`replaceString: "zizmor==1.25.2"`, v1.30.0-rc1 correctly ignored as a prerelease), and that `macos` is still extracted from the three workflows but no longer produces any update.

Once Silent mode is off, four updates are waiting: Sparkle `from: "2.9.5"`, the github-actions group, betterleaks v1.7.4 and zizmor 1.29.0. The Sparkle PR will bump the constraint in `Package.swift` without touching `Package.resolved` (still pinned at 2.9.4) — harmless, since CI runs a bare `swift build` and re-resolves.