### PR TITLE
test(flaky): silence the FSWatcher echo and stop the sizing waits from giving up quietly

### DIFF
--- a/Sources/SpaceMatters/ViewModel/ScanController.swift
+++ b/Sources/SpaceMatters/ViewModel/ScanController.swift
@@ -1370,9 +1370,24 @@ final class ScanController {
 
     // MARK: Live disk watching (SPEC-04)
 
+    /// Live watching pinned off. The incremental-refresh tests forge FSEvents
+    /// batches straight into `handleDiskChanges` to assert *exactly* which
+    /// reconcile decision a batch produces; a real stream on the same fixture
+    /// echoes their own writes back one `FSWatcher` latency later and adds
+    /// re-stats nobody asked for. A flag rather than a bare `stopWatching()`
+    /// because a rescan re-arms the stream.
+    @ObservationIgnored private(set) var liveWatchingSuspended = false
+
+    /// Detach from the disk for good — tests that drive `handleDiskChanges`
+    /// themselves need the forged batches to be the only input.
+    func suspendLiveWatching() {
+        liveWatchingSuspended = true
+        stopWatching()
+    }
+
     private func startWatching() {
         stopWatching()
-        guard isHostScan, !watchPaths.isEmpty else { return }
+        guard !liveWatchingSuspended, isHostScan, !watchPaths.isEmpty else { return }
         let w = FSWatcher(paths: watchPaths) { [weak self] changes in
             Task { @MainActor in self?.handleDiskChanges(changes) }
         }

--- a/Tests/SpaceMattersTests/CleanupTests.swift
+++ b/Tests/SpaceMattersTests/CleanupTests.swift
@@ -25,19 +25,33 @@ import Foundation
                   icon: "shippingbox", note: "fixture", paths: paths)
     }
 
-    static func waitForReady(_ c: CleanupController, timeout: TimeInterval = 5) async {
+    /// Sizing is a real scanner walk, and the poll below pumps the *shared* main
+    /// run loop — every other `@MainActor` suite running in parallel pumps it
+    /// too, so each round costs far more than its 20 ms slice on a loaded
+    /// runner. The deadline is only there to stop a hang, so it is generous;
+    /// what matters is that expiring is *reported*. Giving up silently is what
+    /// turned one slow CI sizing into five bogus failures further down
+    /// `toggleAllCyclesTriState` — a row that was merely still `.pending` reads
+    /// exactly like a row that was never there.
+    static func waitForReady(_ c: CleanupController, timeout: TimeInterval = 60,
+                             sourceLocation: SourceLocation = #_sourceLocation) async {
         let deadline = Date().addingTimeInterval(timeout)
         while c.state != .ready && Date() < deadline {
             RunLoop.main.run(until: Date().addingTimeInterval(0.02))
             await Task.yield()
         }
+        #expect(c.state == .ready, "timed out waiting for .ready, still \(c.state)",
+                sourceLocation: sourceLocation)
     }
 
-    static func waitForCleaning(_ c: CleanupController, timeout: TimeInterval = 5) async {
+    static func waitForCleaning(_ c: CleanupController, timeout: TimeInterval = 60,
+                                sourceLocation: SourceLocation = #_sourceLocation) async {
         let deadline = Date().addingTimeInterval(timeout)
         while c.state != .cleaning && Date() < deadline {
             await Task.yield()
         }
+        #expect(c.state == .cleaning, "timed out waiting for .cleaning, still \(c.state)",
+                sourceLocation: sourceLocation)
     }
 
     // MARK: Catalog

--- a/Tests/SpaceMattersTests/IncrementalRefreshTests.swift
+++ b/Tests/SpaceMattersTests/IncrementalRefreshTests.swift
@@ -24,6 +24,14 @@ import Foundation
         let c = ScanController()
         c.scan(url: root)
         await NavigationTests.waitForScan(c)
+        // The forged batches must be the *only* input. A real FSWatcher is armed
+        // on this same fixture, and it echoes the writes these tests make back
+        // one second later — a second batch for paths already reconciled, which
+        // lands as an extra re-stat or subtree pass. Harmless to the tree (both
+        // are idempotent), fatal to any assertion that counts them: it flaked
+        // `autoRestatCount == 1` on a loaded runner, where a cycle outlives the
+        // watcher's latency.
+        c.suspendLiveWatching()
         return c
     }
 
@@ -125,8 +133,9 @@ import Foundation
         #expect(c.dirtyNeeds[alphaPath] == .restat)
 
         await c.refreshDirty()
-        // NB: no `dirtyPaths.isEmpty` assert — the *real* FSWatcher also runs on
-        // this temp dir and its echo of our write may legitimately re-mark it.
+        // The watcher is suspended, so nothing re-marks the path behind us: the
+        // dirty set must drain completely.
+        #expect(c.dirtyPaths.isEmpty)
         #expect(alpha.directFileCount == 2)
         // Identity preserved — the precise path never went through invalidate.
         #expect(NavigationTests.child(c.root!, "alpha") === alpha)


### PR DESCRIPTION
Two unrelated flakes surfaced in the same CI run ([31976426203](https://github.com/Evariops/SpaceMatters/actions/runs/31976426203/job/95236667728)).

## 1. `denseBurstCoalescesToItsClusterAncestor` — reproduced

```
✘ IncrementalRefreshTests.swift:317: Expectation failed: (c.autoRestatCount → 2) == 1
```

The suite's premise — *"forge FSEvents batches directly into `handleDiskChanges` — no FSEvents latency"* — was never true. `Self.scanned(root)` calls `scan(url:)`, which arms a **real `FSWatcher`** (1 s latency) on the fixture. The tests write real files, so the watcher echoes their own writes back a second later. That second batch re-marks paths the cycle already reconciled and lands as an extra re-stat or subtree pass.

Idempotent for the tree — which is why `waitUntil` still exits and the aggregate assertions pass — but fatal for anything that *counts* the passes. On a loaded runner a reconcile cycle (20 directories, parallel) outlives the watcher's latency, so the echo arrives while the test is still waiting.

The suite half-knew this already: `preciseEventLeadsToRestatOnRefresh` carried an `NB:` dropping a `dirtyPaths.isEmpty` assert *for exactly this reason*. The workaround was never generalised.

**Fix.** `ScanController` gains a `liveWatchingSuspended` flag — a flag rather than a bare `stopWatching()`, because a rescan re-arms the stream — and the `scanned()` helper pins the watcher off so the forged batches are the only input. The dropped assert comes back.

## 2. `toggleAllCyclesTriState` — diagnosed, not reproduced

```
✘ CleanupTests.swift:343: Expectation failed: (c.selectedRows.count → 1) == 2
✘ CleanupTests.swift:346: Expectation failed: (c.selectAllState → .all) == .some
… 3 more, the whole tri-state cycle shifted by one
```

Never fell locally in 40 loaded runs, so this one is a diagnostic rather than a reproduction — worth flagging when reviewing.

All five failures are consistent with a single cause: the `test-cache-2` row was still `.pending`, so not bulk-selectable, so every step of the cycle shifts. Alternatives ruled out — `blockedReason` and `detect` are deterministic for that id, and a `sized(0)` would need the scanner to miss a 4 KiB file.

The culprit is `waitForReady`. It polls `RunLoop.main.run(until:)`, and all 26 parallel `@MainActor` suites pump that same shared run loop, so each round costs far more than its 20 ms slice: the 5 s budget went to mutual blocking, not to work. Then it **gave up in silence** — which is what let a timeout masquerade as five incoherent assertions further down.

**Fix.** The deadline exists only to stop a hang, so it is now generous (60 s); more importantly both waits now `#expect` their condition, reporting `timed out waiting for .ready, still sizing` at the call site instead of failing obscurely downstream.

## Verification

Full suite, 20 iterations, under 28 spinners on 14 cores:

| | before | after |
|---|---|---|
| `IncrementalRefreshTests:317` | 10 / 20 failed | **0 / 20** |

SwiftLint `--strict` clean.

## Out of scope

`StructuralIntegrityTests.swift:33` also fell once in 20 loaded runs — not in the CI run above, and untouched here. The single `await Task.yield()` at line 29 assumes the child task reaches its first suspension in one scheduler turn; under load it sometimes runs to completion, `ok` is `true` and the file is really deleted. It needs an observable rendezvous point, so it belongs in its own change. Its 0/20 here proves nothing at a 1-in-20 rate.